### PR TITLE
base: Use Fedora 30 for godot-fedora:latest

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM fedora:29
+FROM fedora:30
 
 WORKDIR /root
 


### PR DESCRIPTION
Note: I branched off the current `master` branch to 3.1, so that we can keep the same containers for 3.1.x and upgrade them for 3.2/master.