### PR TITLE
ubuntu: Use xz-utils for mono 6.0.x

### DIFF
--- a/Dockerfile.ubuntu-32
+++ b/Dockerfile.ubuntu-32
@@ -13,12 +13,12 @@ RUN apt-get update && \
     echo 'deb http://ppa.launchpad.net/mc3man/trusty-media/ubuntu trusty main' >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get install -y gcc-8 g++-8 libudev-dev libx11-dev libxcursor-dev libxrandr-dev libasound2-dev libpulse-dev \
-            libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev libxi-dev libxinerama-dev git scons cmake perl make bzip2 yasm && \
+            libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev libxi-dev libxinerama-dev git scons cmake perl make xz-utils yasm && \
     ln -sf /usr/bin/gcc-ranlib-8 /usr/bin/gcc-ranlib && \
     ln -sf /usr/bin/gcc-ar-8 /usr/bin/gcc-ar && \
     ln -sf /usr/bin/gcc-8 /usr/bin/gcc && \
     ln -sf /usr/bin/g++-8 /usr/bin/g++ && \
-    wget -O- https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.bz2 | tar xj && \
+    wget -O- https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.xz | tar xJ && \
     cd mono-${mono_version} && \
     ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var/lib/mono --disable-boehm --host=i386-linux-gnu && \
     make -j && \
@@ -35,8 +35,5 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/ && \
     rm *.deb && \
     rm -rf /root/mono-${mono_version}
-
-ENV MONO32_PREFIX=/usr
-ENV MONO64_PREFIX=/usr
 
 CMD ['/bin/bash']

--- a/Dockerfile.ubuntu-64
+++ b/Dockerfile.ubuntu-64
@@ -13,12 +13,12 @@ RUN apt-get update && \
     echo 'deb http://ppa.launchpad.net/mc3man/trusty-media/ubuntu trusty main' >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get install -y gcc-8 g++-8 libudev-dev libx11-dev libxcursor-dev libxrandr-dev libasound2-dev libpulse-dev \
-            libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev libxi-dev libxinerama-dev git scons cmake perl make bzip2 yasm && \
+            libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev libxi-dev libxinerama-dev git scons cmake perl make xz-utils yasm && \
     ln -sf /usr/bin/gcc-ranlib-8 /usr/bin/gcc-ranlib && \
     ln -sf /usr/bin/gcc-ar-8 /usr/bin/gcc-ar && \
     ln -sf /usr/bin/gcc-8 /usr/bin/gcc && \
     ln -sf /usr/bin/g++-8 /usr/bin/g++ && \
-    wget -O- https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.bz2 | tar xj && \
+    wget -O- https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.xz | tar xJ && \
     cd mono-${mono_version} && \
     ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var/lib/mono --disable-boehm --host=x86_64-linux-gnu && \
     make -j && \
@@ -35,8 +35,5 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/ && \
     rm *.deb && \
     rm -rf /root/mono-${mono_version}
-
-ENV MONO32_PREFIX=/usr
-ENV MONO64_PREFIX=/usr
 
 CMD ['/bin/bash']


### PR DESCRIPTION
Since 6.0.0.x upstream changed from `tar.bz2` to `tar.xz`: https://download.mono-project.com/sources/mono/

I think we should use the latest stable for 3.2, so this change makes sense in the master branch.

Note that Ubuntu 14.04.x is EOL, and Mono upstream stopped providing new packages for msbuild since one year. Right now it seems to still be working, but I guess eventually @neikeq might need a more recent msbuild.

I've started work on a CentOS 7 based container, which is still supported by RedHat, and for which Mono upstream still provides new packages. With the [SCL](https://wiki.centos.org/AdditionalResources/Repositories/SCL) we can have GCC 8, which is nice, and we get an even older glibc than on Ubuntu, so also good for back compat. One drawback: CentOS doesn't provide the SCL for i686, so the options would be:
- keep `ubuntu-32` for this Linux 32-bit
- drop 32-bit Linux support from official builds
- build 32-bit Linux binaries against CentOS 7's older toolchain

I'll make a PR with the 64-bit CentOS 7 dockerfile.