### PR TITLE
[WIP] linux: Add CentOS 7 based container for x86_64

### DIFF
--- a/Dockerfile.linux-64
+++ b/Dockerfile.linux-64
@@ -1,0 +1,32 @@
+FROM centos:7
+
+ARG mono_version
+
+RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
+    yum update && \
+    yum install -y centos-release-scl && \
+    yum install -y devtoolset-8-toolchain && \
+    echo "source scl_source enable devtoolset-8" >> /root/.bashrc && \
+    yum install -y git scons pkgconfig libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel libXi-devel \
+            mesa-libGL-devel mesa-libGLU-devel alsa-lib-devel pulseaudio-libs-devel libudev-devel yasm && \
+    yum install -y automake autoconf bzip2 libtool cmake curl make patch perl python which xz && \
+    yum clean all && \
+    source /root/.bashrc && which gcc && which g++ && \
+    cd /root && \
+    if [ ${mono_version%%.*} -ge 6 ]; then \
+        curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.xz | tar xJ; \
+    else \
+        curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.bz2 | tar xj; \
+    fi && \
+    cd mono-${mono_version} && \
+    ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var/lib/mono --disable-boehm --host=x86_64-linux-gnu && \
+    make -j && \
+    make install && \
+    cert-sync /etc/pki/tls/certs/ca-bundle.crt && \
+    rm -rf /root/mono-${mono_version} && \
+    rpm -ivh --nodeps https://download.mono-project.com/repo/centos7-stable/m/msbuild/msbuild-16.1+xamarinxplat.2019.06.05.11.19-0.xamarin.4.epel7.noarch.rpm \
+                      https://download.mono-project.com/repo/centos7-stable/m/msbuild/msbuild-sdkresolver-16.1+xamarinxplat.2019.06.05.11.19-0.xamarin.4.epel7.noarch.rpm \
+                      https://download.mono-project.com/repo/centos7-stable/m/msbuild-libhostfxr/msbuild-libhostfxr-3.0.0.2019.04.16.02.13-0.xamarin.4.epel7.x86_64.rpm \
+                      https://download.mono-project.com/repo/centos7-stable/n/nuget/nuget-5.1.0.6013.bin-0.xamarin.1.epel7.noarch.rpm
+
+CMD ['/bin/bash']

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ fi
 
 if [ -z "$1" ]; then
   echo "usage: $0 <mono version"
-  echo 
+  echo
   echo "For example: $0 5.16.0.220"
   echo
   exit 1
@@ -29,7 +29,8 @@ $podman build --build-arg mono_version=${mono_version} -t godot-mono:${mono_vers
 $podman build --build-arg mono_version=${mono_version} -t godot-mono-glue:latest -f Dockerfile.mono-glue .
 $podman build --build-arg mono_version=${mono_version} -v $(pwd)/files:/root/files -t godot-windows:latest -f Dockerfile.windows .
 $podman build --build-arg mono_version=${mono_version} -t godot-ubuntu-32:latest -f Dockerfile.ubuntu-32 .
-$podman build --build-arg mono_version=${mono_version} -t godot-ubuntu-64:latest -f Dockerfile.ubuntu-64 .
+#$podman build --build-arg mono_version=${mono_version} -t godot-ubuntu-64:latest -f Dockerfile.ubuntu-64 .
+$podman build --build-arg mono_version=${mono_version} -t godot-linux-64:latest -f Dockerfile.linux-64 .
 
 $podman build -t godot-android:latest -f Dockerfile.android .
 $podman build -t godot-javascript:latest -f Dockerfile.javascript .


### PR DESCRIPTION
Thanks to the SCL, we can get the GCC 8 toolchain,
and GCC 9 should be made available once 9.3 is released.

The setup is cleaner than on Ubuntu and we have an even
older glibc version for compatibility. The drawback is
that there is no SCL for CentOS 7 i686, and Mono upstream
also doesn't provide packages for it (though we could build
them from the src.rpm).

And of course, Ubuntu 14.04 is now EOL so it makes sense to
make our builds on a still supported release.

---

As mentioned on #3, if we want to use CentOS 7 for x86_64 Linux builds, we might still need to keep `ubuntu-32` for i686 builds, as CentOS doesn't seem to provide the GCC 8 toolchain out of the box for it.

I did find the `devtoolset-7` for RHEL7 i686 on the CloudLinux repo though, so I guess it might still possible to get this somehow? https://www.repo.cloudlinux.com/cloudlinux/7.6/sclo/devtoolset-7/i386/