### PR TITLE
mono: Add support for mono 6.0.x

### DIFF
--- a/Dockerfile.mono
+++ b/Dockerfile.mono
@@ -4,15 +4,21 @@ ARG mono_version
 
 RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi
 
-RUN dnf -y install cmake gcc gcc-c++ make which perl python curl bzip2 && dnf clean all && \
-    curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.bz2 | tar xj && \
+RUN dnf -y install autoconf automake libtool cmake gcc gcc-c++ make which perl python curl bzip2 xz && dnf clean all && \
+    if [ ${mono_version%%.*} -ge 6 ]; then \
+        curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.xz | tar xJ; \
+    else \
+        curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.bz2 | tar xj; \
+    fi && \
     cd mono-${mono_version} && \
-    ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var/lib/mono --disable-boehm && make -j && make install && make distclean && \
+    autoreconf -vfi && \
+    ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var/lib/mono --disable-boehm && \
+    make -j && make install && make distclean && \
     cd /root && \
     rm -rf mono-${mono_version} && \
-    cert-sync /etc/pki/tls/certs/ca-bundle.crt && \
-    rpm -ivh --nodeps https://download.mono-project.com/repo/centos7-stable/m/msbuild/msbuild-16.0+xamarinxplat.2018.09.26.17.53-0.xamarin.3.epel7.noarch.rpm \
-                      https://download.mono-project.com/repo/centos7-stable/m/msbuild-libhostfxr/msbuild-libhostfxr-2.0.0.2017.07.06.00.01-0.xamarin.1.epel7.x86_64.rpm \
-                      https://download.mono-project.com/repo/centos7-stable/m/msbuild/msbuild-sdkresolver-16.0+xamarinxplat.2018.09.26.17.53-0.xamarin.3.epel7.noarch.rpm \
-                      https://download.mono-project.com/repo/centos7-stable/n/nuget/nuget-4.7.0.5148.bin-0.xamarin.1.epel7.noarch.rpm
+    cert-sync /etc/pki/tls/certs/ca-bundle.crt
 
+RUN rpm -ivh --nodeps https://download.mono-project.com/repo/centos8-stable/m/msbuild/msbuild-16.0+xamarinxplat.2018.09.26.17.53-0.xamarin.5.epel8.noarch.rpm \
+                      https://download.mono-project.com/repo/centos8-stable/m/msbuild-libhostfxr/msbuild-libhostfxr-2.0.0.2017.07.06.00.01-0.xamarin.3.epel8.x86_64.rpm \
+                      https://download.mono-project.com/repo/centos8-stable/m/msbuild/msbuild-sdkresolver-16.0+xamarinxplat.2018.09.26.17.53-0.xamarin.5.epel8.noarch.rpm \
+                      https://download.mono-project.com/repo/centos8-stable/n/nuget/nuget-4.7.0.5148.bin-0.xamarin.2.epel8.noarch.rpm

--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -28,8 +28,13 @@ RUN dnf -y install automake autoconf bzip2-devel clang git libicu-devel libtool 
     mkdir -p ${CLANG_LIB_DIR}/lib/darwin && \
     cp -rv /root/osxcross/build/compiler-rt/include/sanitizer ${CLANG_LIB_DIR}/include && \
     cp -v /root/osxcross/build/compiler-rt/build/lib/darwin/*.a ${CLANG_LIB_DIR}/lib/darwin && \
-    cp -v /root/osxcross/build/compiler-rt/build/lib/darwin/*.dylib ${CLANG_LIB_DIR}/lib/darwin && \
-    curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.bz2 | tar xj && \
+    cp -v /root/osxcross/build/compiler-rt/build/lib/darwin/*.dylib ${CLANG_LIB_DIR}/lib/darwin
+
+RUN if [ ${mono_version%%.*} -ge 6 ]; then \
+        curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.xz | tar xJ; \
+    else \
+        curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.bz2 | tar xj; \
+    fi && \
     cd mono-${mono_version} && \
     patch -p1 < /root/files/patches/fix-mono-configure.diff && \
     export PATH=/root/osxcross/target/bin:$PATH && \

--- a/Dockerfile.ubuntu-32
+++ b/Dockerfile.ubuntu-32
@@ -13,12 +13,16 @@ RUN apt-get update && \
     echo 'deb http://ppa.launchpad.net/mc3man/trusty-media/ubuntu trusty main' >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get install -y gcc-8 g++-8 libudev-dev libx11-dev libxcursor-dev libxrandr-dev libasound2-dev libpulse-dev \
-            libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev libxi-dev libxinerama-dev git scons cmake perl make bzip2 yasm && \
+            libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev libxi-dev libxinerama-dev git scons cmake perl make curl bzip2 xz-utils yasm && \
     ln -sf /usr/bin/gcc-ranlib-8 /usr/bin/gcc-ranlib && \
     ln -sf /usr/bin/gcc-ar-8 /usr/bin/gcc-ar && \
     ln -sf /usr/bin/gcc-8 /usr/bin/gcc && \
     ln -sf /usr/bin/g++-8 /usr/bin/g++ && \
-    wget -O- https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.bz2 | tar xj && \
+    if [ ${mono_version%%.*} -ge 6 ]; then \
+        curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.xz | tar xJ; \
+    else \
+        curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.bz2 | tar xj; \
+    fi && \
     cd mono-${mono_version} && \
     ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var/lib/mono --disable-boehm --host=i386-linux-gnu && \
     make -j && \
@@ -35,8 +39,5 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/ && \
     rm *.deb && \
     rm -rf /root/mono-${mono_version}
-
-ENV MONO32_PREFIX=/usr
-ENV MONO64_PREFIX=/usr
 
 CMD ['/bin/bash']

--- a/Dockerfile.ubuntu-64
+++ b/Dockerfile.ubuntu-64
@@ -13,12 +13,16 @@ RUN apt-get update && \
     echo 'deb http://ppa.launchpad.net/mc3man/trusty-media/ubuntu trusty main' >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get install -y gcc-8 g++-8 libudev-dev libx11-dev libxcursor-dev libxrandr-dev libasound2-dev libpulse-dev \
-            libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev libxi-dev libxinerama-dev git scons cmake perl make bzip2 yasm && \
+            libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev libxi-dev libxinerama-dev git scons cmake perl make curl bzip2 xz-utils yasm && \
     ln -sf /usr/bin/gcc-ranlib-8 /usr/bin/gcc-ranlib && \
     ln -sf /usr/bin/gcc-ar-8 /usr/bin/gcc-ar && \
     ln -sf /usr/bin/gcc-8 /usr/bin/gcc && \
     ln -sf /usr/bin/g++-8 /usr/bin/g++ && \
-    wget -O- https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.bz2 | tar xj && \
+    if [ ${mono_version%%.*} -ge 6 ]; then \
+        curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.xz | tar xJ; \
+    else \
+        curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.bz2 | tar xj; \
+    fi && \
     cd mono-${mono_version} && \
     ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var/lib/mono --disable-boehm --host=x86_64-linux-gnu && \
     make -j && \
@@ -35,8 +39,5 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/ && \
     rm *.deb && \
     rm -rf /root/mono-${mono_version}
-
-ENV MONO32_PREFIX=/usr
-ENV MONO64_PREFIX=/usr
 
 CMD ['/bin/bash']

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -4,35 +4,43 @@ ARG mono_version
 
 RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi
 
-RUN dnf -y install scons mingw32-gcc mingw32-gcc-c++ mingw32-winpthreads-static mingw64-gcc mingw64-gcc-c++ mingw64-winpthreads-static yasm && dnf clean all && \
-    rpm -Uvh --replacepkgs /root/files/mingw-binutils-generic-2.30-5.fc29.godot.x86_64.rpm \
-                           /root/files/mingw64-binutils-2.30-5.fc29.godot.x86_64.rpm \
-                           /root/files/mingw32-binutils-2.30-5.fc29.godot.x86_64.rpm && \
-    curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.bz2 | tar xj && \
+RUN dnf -y install scons mingw32-gcc mingw32-gcc-c++ mingw32-winpthreads-static mingw64-gcc mingw64-gcc-c++ mingw64-winpthreads-static yasm bzip2 xz && dnf clean all && \
+    rpm -Uvh --force /root/files/mingw-binutils-generic-2.30-5.fc29.godot.x86_64.rpm \
+                     /root/files/mingw64-binutils-2.30-5.fc29.godot.x86_64.rpm \
+                     /root/files/mingw32-binutils-2.30-5.fc29.godot.x86_64.rpm && \
+    if [ ${mono_version%%.*} -ge 6 ]; then \
+        curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.xz | tar xJ; \
+    else \
+        curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.bz2 | tar xj; \
+    fi && \
+    cp -r mono-${mono_version} mono-${mono_version}-32 && \
     cd mono-${mono_version} && \
     ./configure --prefix=/root/dependencies/mono-64 --host=x86_64-w64-mingw32 --disable-boehm --disable-mcs-build --disable-executables && \
     echo '#define HAVE_STRUCT_SOCKADDR_IN6 1' >> config.h && \
     make -j && \
     make install && \
-    make distclean && \
+    cd .. && \
+    rm -rf mono-${mono_version} && \
     cp /root/dependencies/mono-64/bin/libMonoPosixHelper.dll /root/dependencies/mono-64/bin/MonoPosixHelper.dll && \
     rm -f /root/dependencies/mono-64/bin/mono /root/dependencies/mono-64/bin/mono-sgen && \
     ln -s /usr/bin/mono /root/dependencies/mono-64/bin/mono && \
     ln -s /usr/bin/mono-sgen /root/dependencies/mono-64/bin/mono-sgen && \
     ln -sf /usr/lib/mono/* /root/dependencies/mono-64/lib/mono || /bin/true && \
-    cp -rvp /etc/mono /root/dependencies/mono-64/etc && \
+    cp -rvp /etc/mono /root/dependencies/mono-64/etc
+
+RUN cd mono-${mono_version}-32 && \
     ./configure --prefix=/root/dependencies/mono-32 --host=i686-w64-mingw32 --disable-boehm --disable-mcs-build --disable-executables && \
     echo '#define HAVE_STRUCT_SOCKADDR_IN6 1' >> config.h && \
     make -j && \
     make install && \
-    make distclean && \
+    cd .. && \
+    rm -rf mono-${mono_version}-32 && \
     cp /root/dependencies/mono-32/bin/libMonoPosixHelper.dll /root/dependencies/mono-32/bin/MonoPosixHelper.dll && \
     rm -f /root/dependencies/mono-32/bin/mono /root/dependencies/mono-32/bin/mono-sgen && \
     ln -s /usr/bin/mono /root/dependencies/mono-32/bin/mono && \
     ln -s /usr/bin/mono-sgen /root/dependencies/mono-32/bin/mono-sgen && \
     ln -sf /usr/lib/mono/* /root/dependencies/mono-32/lib/mono || /bin/true && \
-    cp -rvp /etc/mono /root/dependencies/mono-32/etc && \
-    rm -rf /root/mono-${mono_version}
+    cp -rvp /etc/mono /root/dependencies/mono-32/etc
 
 ENV MONO32_PREFIX=/root/dependencies/mono-32
 ENV MONO64_PREFIX=/root/dependencies/mono-64


### PR DESCRIPTION
This should actually be merged before #3 and #4 which build upon this image.

Mono 6.0.x now ships as `.tar.xz` so some changes were needed. It also seems to have a bogus `configure` by default, so we fix it with `autoreconf -vfi`.

I also bumped all msbuild packages to their latest version from `centos8-stable`.