### PR TITLE
windows: Use xz for mono 6.0.x, workaround distclean bug

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -4,35 +4,41 @@ ARG mono_version
 
 RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi
 
-RUN dnf -y install scons mingw32-gcc mingw32-gcc-c++ mingw32-winpthreads-static mingw64-gcc mingw64-gcc-c++ mingw64-winpthreads-static yasm && dnf clean all && \
-    rpm -Uvh --replacepkgs /root/files/mingw-binutils-generic-2.30-5.fc29.godot.x86_64.rpm \
-                           /root/files/mingw64-binutils-2.30-5.fc29.godot.x86_64.rpm \
-                           /root/files/mingw32-binutils-2.30-5.fc29.godot.x86_64.rpm && \
-    curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.bz2 | tar xj && \
+RUN dnf -y install scons mingw32-gcc mingw32-gcc-c++ mingw32-winpthreads-static mingw64-gcc mingw64-gcc-c++ mingw64-winpthreads-static yasm xz && dnf clean all && \
+    rpm -Uvh --force /root/files/mingw-binutils-generic-2.30-5.fc29.godot.x86_64.rpm \
+                     /root/files/mingw64-binutils-2.30-5.fc29.godot.x86_64.rpm \
+                     /root/files/mingw32-binutils-2.30-5.fc29.godot.x86_64.rpm && \
+    curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.xz -o mono-${mono_version}.tar.xz && \
+    tar xJf mono-${mono_version}.tar.xz && \
     cd mono-${mono_version} && \
     ./configure --prefix=/root/dependencies/mono-64 --host=x86_64-w64-mingw32 --disable-boehm --disable-mcs-build --disable-executables && \
     echo '#define HAVE_STRUCT_SOCKADDR_IN6 1' >> config.h && \
     make -j && \
     make install && \
-    make distclean && \
+    cd .. && \
+    rm -rf mono-${mono_version} && \
     cp /root/dependencies/mono-64/bin/libMonoPosixHelper.dll /root/dependencies/mono-64/bin/MonoPosixHelper.dll && \
     rm -f /root/dependencies/mono-64/bin/mono /root/dependencies/mono-64/bin/mono-sgen && \
     ln -s /usr/bin/mono /root/dependencies/mono-64/bin/mono && \
     ln -s /usr/bin/mono-sgen /root/dependencies/mono-64/bin/mono-sgen && \
     ln -sf /usr/lib/mono/* /root/dependencies/mono-64/lib/mono || /bin/true && \
-    cp -rvp /etc/mono /root/dependencies/mono-64/etc && \
+    cp -rvp /etc/mono /root/dependencies/mono-64/etc
+
+RUN tar xJf mono-${mono_version}.tar.xz && \
+    cd mono-${mono_version} && \
     ./configure --prefix=/root/dependencies/mono-32 --host=i686-w64-mingw32 --disable-boehm --disable-mcs-build --disable-executables && \
     echo '#define HAVE_STRUCT_SOCKADDR_IN6 1' >> config.h && \
     make -j && \
     make install && \
-    make distclean && \
+    cd .. && \
+    rm -rf mono-${mono_version} && \
+    rm -f mono-${mono_version}.tar.xz && \
     cp /root/dependencies/mono-32/bin/libMonoPosixHelper.dll /root/dependencies/mono-32/bin/MonoPosixHelper.dll && \
     rm -f /root/dependencies/mono-32/bin/mono /root/dependencies/mono-32/bin/mono-sgen && \
     ln -s /usr/bin/mono /root/dependencies/mono-32/bin/mono && \
     ln -s /usr/bin/mono-sgen /root/dependencies/mono-32/bin/mono-sgen && \
     ln -sf /usr/lib/mono/* /root/dependencies/mono-32/lib/mono || /bin/true && \
-    cp -rvp /etc/mono /root/dependencies/mono-32/etc && \
-    rm -rf /root/mono-${mono_version}
+    cp -rvp /etc/mono /root/dependencies/mono-32/etc
 
 ENV MONO32_PREFIX=/root/dependencies/mono-32
 ENV MONO64_PREFIX=/root/dependencies/mono-64


### PR DESCRIPTION
Same as #5, since the mono 6.0+ tarballs use .tar.xz, we need
some changes.

I also run into a build issue due to `make distclean` being bogus
in 6.0.0.319 (mono/mono#16605), so I worked it around by starting
from a clean folder for each build.

The hotfixed binutils packages should likely be rebuilt against
Fedora 30's mingw-binutils, but I didn't find the src.rpm in the
repo to do it. There were no functional changes between F29 and
F30's mingw-binutils though, so we should be fine as is:
https://src.fedoraproject.org/rpms/mingw-binutils/commits/f30

The `MONO32_PREFIX` and `MONO64_PREFIX` are no longer used by
the buildsystem (replaced by a `mono_prefix` build option), but
I kept them as they're convenient to point to the relevant install
locations.