### PR TITLE
android: Set up Mono buildsystem

### DIFF
--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -1,13 +1,30 @@
-FROM godot-fedora:latest
+ARG mono_version
+FROM godot-mono:${mono_version}
+ARG mono_version
 
 RUN dnf -y install scons java-1.8.0-openjdk-devel ncurses-compat-libs unzip which gcc gcc-c++ && \
+    mkdir sdk && cd sdk && \
     curl -LO https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip && \
     unzip sdk-tools-linux-4333796.zip && \
     rm sdk-tools-linux-4333796.zip && \
     yes | tools/bin/sdkmanager --licenses && \
-    tools/bin/sdkmanager ndk-bundle 'platforms;android-23' 'build-tools;19.1.0' 'build-tools;28.0.3' 'platforms;android-28' 
+    tools/bin/sdkmanager ndk-bundle 'build-tools;28.0.3' 'platforms;android-28' 'cmake;3.10.2.4988404' && \
+    cd ..
 
-ENV ANDROID_HOME=/root/
-ENV ANDROID_NDK_ROOT=/root/ndk-bundle/
+ENV ANDROID_HOME=/root/sdk/
+ENV ANDROID_NDK_ROOT=/root/sdk/ndk-bundle/
+
+RUN dnf -y install git patch && \
+    git clone https://github.com/mono/mono --branch mono-${mono_version} --single-branch && \
+    cd mono && git submodule update --init && \
+    patch -p1 < /root/files/patches/fix-mono-android-tkill.diff && \
+    cd .. && \
+    git clone https://github.com/godotengine/godot-mono-builds && \
+    cd godot-mono-builds && \
+    git checkout 9efec19e6b61fdc7201067cff4dd5b741399ae31 && \
+    ./build_mono_android.py configure --target=all --mono-sources=/root/mono && \
+    ./build_mono_android.py make --target=all --mono-sources=/root/mono && \
+    cd .. && \
+    rm -rf /root/mono /root/godot-mono-builds
 
 CMD ['/bin/bash']

--- a/build.sh
+++ b/build.sh
@@ -30,8 +30,8 @@ $podman build --build-arg mono_version=${mono_version} -t godot-mono-glue:latest
 $podman build --build-arg mono_version=${mono_version} -v $(pwd)/files:/root/files -t godot-windows:latest -f Dockerfile.windows .
 $podman build --build-arg mono_version=${mono_version} -t godot-ubuntu-32:latest -f Dockerfile.ubuntu-32 .
 $podman build --build-arg mono_version=${mono_version} -t godot-ubuntu-64:latest -f Dockerfile.ubuntu-64 .
+$podman build --build-arg mono_version=${mono_version} -t godot-android:latest -f Dockerfile.android .
 
-$podman build -t godot-android:latest -f Dockerfile.android .
 $podman build -t godot-javascript:latest -f Dockerfile.javascript .
 
 $podman build -t godot-xcode-packer:latest -f Dockerfile.xcode -v $(pwd)/files:/root/files .

--- a/files/patches/fix-mono-android-tkill.diff
+++ b/files/patches/fix-mono-android-tkill.diff
@@ -1,0 +1,70 @@
+diff --git a/libgc/include/private/gcconfig.h b/libgc/include/private/gcconfig.h
+index e2bdf13ac3e..f962200ba4e 100644
+--- a/libgc/include/private/gcconfig.h
++++ b/libgc/include/private/gcconfig.h
+@@ -2255,6 +2255,14 @@
+ #   define GETPAGESIZE() getpagesize()
+ # endif
+ 
++#if defined(HOST_ANDROID) && !(__ANDROID_API__ >= 23) \
++    && ((defined(MIPS) && (CPP_WORDSZ == 32)) \
++        || defined(ARM32) || defined(I386) /* but not x32 */)
++  /* tkill() exists only on arm32/mips(32)/x86. */
++  /* NDK r11+ deprecates tkill() but keeps it for Mono clients. */
++# define USE_TKILL_ON_ANDROID
++#endif
++
+ # if defined(SUNOS5) || defined(DRSNX) || defined(UTS4)
+ 	    /* OS has SVR4 generic features.  Probably others also qualify.	*/
+ #   define SVR4
+diff --git a/libgc/pthread_stop_world.c b/libgc/pthread_stop_world.c
+index f93ce26b562..4a49a6d578c 100644
+--- a/libgc/pthread_stop_world.c
++++ b/libgc/pthread_stop_world.c
+@@ -336,7 +336,7 @@ void GC_push_all_stacks()
+ pthread_t GC_stopping_thread;
+ int GC_stopping_pid;
+ 
+-#ifdef HOST_ANDROID
++#ifdef USE_TKILL_ON_ANDROID
+ static
+ int android_thread_kill(pid_t tid, int sig)
+ {
+diff --git a/mono/metadata/threads.c b/mono/metadata/threads.c
+index ad9b8823f8f..3542b32b540 100644
+--- a/mono/metadata/threads.c
++++ b/mono/metadata/threads.c
+@@ -77,8 +77,12 @@ mono_native_thread_join_handle (HANDLE thread_handle, gboolean close_handle);
+ #include <zircon/syscalls.h>
+ #endif
+ 
+-#if defined(HOST_ANDROID) && !defined(TARGET_ARM64) && !defined(TARGET_AMD64)
+-#define USE_TKILL_ON_ANDROID 1
++#if defined(HOST_ANDROID) && !(__ANDROID_API__ >= 23) \
++    && ((defined(MIPS) && (CPP_WORDSZ == 32)) \
++        || defined(ARM32) || defined(I386) /* but not x32 */)
++  /* tkill() exists only on arm32/mips(32)/x86. */
++  /* NDK r11+ deprecates tkill() but keeps it for Mono clients. */
++# define USE_TKILL_ON_ANDROID
+ #endif
+ 
+ #ifdef HOST_ANDROID
+diff --git a/mono/utils/mono-threads-posix.c b/mono/utils/mono-threads-posix.c
+index 3e4bf93de5f..79c9f731fe7 100644
+--- a/mono/utils/mono-threads-posix.c
++++ b/mono/utils/mono-threads-posix.c
+@@ -31,8 +31,12 @@
+ 
+ #include <errno.h>
+ 
+-#if defined(HOST_ANDROID) && !defined(TARGET_ARM64) && !defined(TARGET_AMD64)
+-#define USE_TKILL_ON_ANDROID 1
++#if defined(HOST_ANDROID) && !(__ANDROID_API__ >= 23) \
++    && ((defined(MIPS) && (CPP_WORDSZ == 32)) \
++        || defined(ARM32) || defined(I386) /* but not x32 */)
++  /* tkill() exists only on arm32/mips(32)/x86. */
++  /* NDK r11+ deprecates tkill() but keeps it for Mono clients. */
++# define USE_TKILL_ON_ANDROID
+ #endif
+ 
+ #ifdef USE_TKILL_ON_ANDROID


### PR DESCRIPTION
Adds support for building Mono templates for Android in 3.2/master.
Expects mono 6.0+ (otherwise we'd have to handle the tarball compression
change from upstream).

We use the script from https://github.com/godotengine/godot-mono-builds
to build Mono for all arches with the right options, and a patch included
in https://github.com/godotengine/godot/blob/master/modules/mono/build_scripts/patches/fix-mono-android-tkill.diff
which is also necessary.

I also moved the SDK to a `sdk` folder to make the `$HOME` more tidy,
especially since the Mono build scripts install the mono toolchains in
`$HOME` too by default.