### PR TITLE
osx: Use xz for mono 6.0.x

### DIFF
--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -29,7 +29,7 @@ RUN dnf -y install automake autoconf bzip2-devel clang git libicu-devel libtool 
     cp -rv /root/osxcross/build/compiler-rt/include/sanitizer ${CLANG_LIB_DIR}/include && \
     cp -v /root/osxcross/build/compiler-rt/build/lib/darwin/*.a ${CLANG_LIB_DIR}/lib/darwin && \
     cp -v /root/osxcross/build/compiler-rt/build/lib/darwin/*.dylib ${CLANG_LIB_DIR}/lib/darwin && \
-    curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.bz2 | tar xj && \
+    curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.xz | tar xJ && \
     cd mono-${mono_version} && \
     patch -p1 < /root/files/patches/fix-mono-configure.diff && \
     export PATH=/root/osxcross/target/bin:$PATH && \


### PR DESCRIPTION
That's the only updated container which I couldn't test building so far, as I don't have access to the relevant SDK.

We'll need to increase our target SDK anyway for 3.2 to keep up with Apple's depreciation of older versions, and iOS will also need a version bump to support ARKit.