### PR TITLE
Fix Docker.javascript not building

### DIFF
--- a/Dockerfile.javascript
+++ b/Dockerfile.javascript
@@ -1,10 +1,10 @@
 FROM godot-fedora:latest
 
-RUN dnf -y install scons git bzip2 xz java-openjdk yasm && dnf clean all && \
+RUN dnf -y install which scons git bzip2 xz java-openjdk yasm && dnf clean all && \
     git clone https://github.com/emscripten-core/emsdk && \
     cd emsdk && \
-    ./emsdk install latest && \
-    ./emsdk activate latest && \
+    ./emsdk install 1.39.0 && \
+    ./emsdk activate 1.39.0 && \
     echo "source /root/emsdk/emsdk_env.sh" >> /root/.bashrc
 
 CMD ['/bin/bash']


### PR DESCRIPTION
Docker.javascript fails to build

```
Cloning into 'emsdk'...
remote: Enumerating objects: 25, done.        
remote: Counting objects: 100% (25/25), done.        
remote: Compressing objects: 100% (21/21), done.        
remote: Total 1694 (delta 11), reused 7 (delta 4), pack-reused 1669        
Receiving objects: 100% (1694/1694), 960.21 KiB | 492.00 KiB/s, done.
Resolving deltas: 100% (1068/1068), done.
./emsdk: line 18: exec: python: not found
```

This docker installs scons which pulls in python3. There is no `python` command.

How do you want to handle it? Especially regarding #13. 
* Add `python` to the list of requested packages (which pulls in python2 [2.7.17])?
* `ln -s python3 python`?

Also, due to this emsdk bug, 
https://github.com/godotengine/godot/issues/33374 
shouldn't we specify a version like 1.39.0?
