### PR TITLE
Install common dependencies in Dockerfile.base

### DIFF
--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -2,7 +2,9 @@ ARG mono_version
 FROM godot-mono:${mono_version}
 ARG mono_version
 
-RUN dnf -y install java-1.8.0-openjdk-devel ncurses-compat-libs gcc gcc-c++ && \
+RUN dnf -y install --setopt=install_weak_deps=False \
+      gcc gcc-c++ java-1.8.0-openjdk-devel ncurses-compat-libs && \
+    dnf clean all && \
     mkdir sdk && cd sdk && \
     curl -LO https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip && \
     unzip sdk-tools-linux-4333796.zip && \

--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -2,7 +2,7 @@ ARG mono_version
 FROM godot-mono:${mono_version}
 ARG mono_version
 
-RUN dnf -y install scons java-1.8.0-openjdk-devel ncurses-compat-libs unzip which gcc gcc-c++ && \
+RUN dnf -y install java-1.8.0-openjdk-devel ncurses-compat-libs gcc gcc-c++ && \
     mkdir sdk && cd sdk && \
     curl -LO https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip && \
     unzip sdk-tools-linux-4333796.zip && \
@@ -14,8 +14,7 @@ RUN dnf -y install scons java-1.8.0-openjdk-devel ncurses-compat-libs unzip whic
 ENV ANDROID_HOME=/root/sdk/
 ENV ANDROID_NDK_ROOT=/root/sdk/ndk-bundle/
 
-RUN dnf -y install git patch && \
-    git clone https://github.com/mono/mono --branch mono-${mono_version} --single-branch && \
+RUN git clone https://github.com/mono/mono --branch mono-${mono_version} --single-branch && \
     cd mono && git submodule update --init && \
     patch -p1 < /root/files/patches/fix-mono-android-tkill.diff && \
     cd .. && \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -2,4 +2,6 @@ FROM fedora:30
 
 WORKDIR /root
 
+RUN dnf install -y bash bzip2 curl git make patch pkgconfig python3 scons unzip which xz && dnf clean all
+
 CMD /bin/true

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -2,6 +2,9 @@ FROM fedora:30
 
 WORKDIR /root
 
-RUN dnf install -y bash bzip2 curl git make patch pkgconfig python3 scons unzip which xz && dnf clean all
+RUN dnf -y upgrade --setopt=install_weak_deps=False && \
+    dnf -y install --setopt=install_weak_deps=False \
+      bash bzip2 curl git make patch pkgconfig python3 scons unzip which xz && \
+    dnf clean all
 
 CMD /bin/true

--- a/Dockerfile.export
+++ b/Dockerfile.export
@@ -1,5 +1,7 @@
 FROM godot-fedora:latest
 
-RUN dnf -y install xorg-x11-server-Xvfb mesa-dri-drivers libXcursor libXinerama libXrandr libXi alsa-lib pulseaudio-libs java-1.8.0-openjdk-devel && dnf clean all
+RUN dnf -y install --setopt=install_weak_deps=False \
+      xorg-x11-server-Xvfb mesa-dri-drivers libXcursor libXinerama libXrandr libXi alsa-lib pulseaudio-libs java-1.8.0-openjdk-devel && \
+    dnf clean all
 
 CMD ['/bin/bash']

--- a/Dockerfile.ios
+++ b/Dockerfile.ios
@@ -1,6 +1,8 @@
 FROM godot-fedora:latest
 
-RUN dnf -y install automake autoconf clang gcc gcc-c++ gcc-objc gcc-objc++ cmake libicu-devel libtool libxml2-devel llvm-devel openssl-devel perl python yasm && \
+RUN dnf -y install --setopt=install_weak_deps=False \
+      automake autoconf clang gcc gcc-c++ gcc-objc gcc-objc++ cmake libicu-devel libtool libxml2-devel llvm-devel openssl-devel perl python yasm && \
+    dnf clean all && \
     git clone https://github.com/tpoechtrager/cctools-port.git && \
     cd /root/cctools-port && \
     sed -i 's#./autogen.sh#libtoolize -c -i --force\n./autogen.sh#' usage_examples/ios_toolchain/build.sh && \

--- a/Dockerfile.ios
+++ b/Dockerfile.ios
@@ -1,6 +1,6 @@
 FROM godot-fedora:latest
 
-RUN dnf -y install automake autoconf clang gcc gcc-c++ gcc-objc gcc-objc++ cmake git libicu-devel libtool libxml2-devel llvm-devel make openssl-devel patch perl python scons xz yasm && \
+RUN dnf -y install automake autoconf clang gcc gcc-c++ gcc-objc gcc-objc++ cmake libicu-devel libtool libxml2-devel llvm-devel openssl-devel perl python yasm && \
     git clone https://github.com/tpoechtrager/cctools-port.git && \
     cd /root/cctools-port && \
     sed -i 's#./autogen.sh#libtoolize -c -i --force\n./autogen.sh#' usage_examples/ios_toolchain/build.sh && \

--- a/Dockerfile.javascript
+++ b/Dockerfile.javascript
@@ -1,6 +1,8 @@
 FROM godot-fedora:latest
 
-RUN dnf -y install java-openjdk yasm && dnf clean all && \
+RUN dnf -y install --setopt=install_weak_deps=False \
+      java-openjdk yasm && \
+    dnf clean all && \
     git clone https://github.com/emscripten-core/emsdk && \
     cd emsdk && \
     ./emsdk install 1.39.0 && \

--- a/Dockerfile.javascript
+++ b/Dockerfile.javascript
@@ -1,6 +1,6 @@
 FROM godot-fedora:latest
 
-RUN dnf -y install which scons git bzip2 xz java-openjdk yasm && dnf clean all && \
+RUN dnf -y install java-openjdk yasm && dnf clean all && \
     git clone https://github.com/emscripten-core/emsdk && \
     cd emsdk && \
     ./emsdk install 1.39.0 && \

--- a/Dockerfile.mono
+++ b/Dockerfile.mono
@@ -4,7 +4,9 @@ ARG mono_version
 
 RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi
 
-RUN dnf -y install autoconf automake libtool cmake gcc gcc-c++ perl python && dnf clean all && \
+RUN dnf -y install --setopt=install_weak_deps=False \
+      autoconf automake cmake gettext gcc gcc-c++ libtool perl python && \
+    dnf clean all && \
     if [ ${mono_version%%.*} -ge 6 ]; then \
         curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.xz | tar xJ; \
     else \

--- a/Dockerfile.mono
+++ b/Dockerfile.mono
@@ -4,7 +4,7 @@ ARG mono_version
 
 RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi
 
-RUN dnf -y install autoconf automake libtool cmake gcc gcc-c++ make which perl python curl bzip2 xz && dnf clean all && \
+RUN dnf -y install autoconf automake libtool cmake gcc gcc-c++ perl python && dnf clean all && \
     if [ ${mono_version%%.*} -ge 6 ]; then \
         curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.xz | tar xJ; \
     else \

--- a/Dockerfile.mono-glue
+++ b/Dockerfile.mono-glue
@@ -2,6 +2,8 @@ ARG mono_version
 FROM godot-mono:${mono_version}
 ARG mono_version
 
-RUN dnf -y install xorg-x11-server-Xvfb libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel libXi-devel mesa-libGL-devel alsa-lib-devel pulseaudio-libs-devel libudev-devel mesa-libGLU-devel mesa-dri-drivers && dnf clean all
+RUN dnf -y install --setopt=install_weak_deps=False \
+      xorg-x11-server-Xvfb libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel libXi-devel alsa-lib-devel pulseaudio-libs-devel libudev-devel mesa-libGL-devel mesa-libGLU-devel mesa-dri-drivers && \
+    dnf clean all
 
 CMD ['/bin/bash']

--- a/Dockerfile.mono-glue
+++ b/Dockerfile.mono-glue
@@ -2,6 +2,6 @@ ARG mono_version
 FROM godot-mono:${mono_version}
 ARG mono_version
 
-RUN dnf -y install scons xorg-x11-server-Xvfb pkgconfig libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel libXi-devel mesa-libGL-devel alsa-lib-devel pulseaudio-libs-devel freetype-devel openssl-devel libudev-devel mesa-libGLU-devel mesa-dri-drivers && dnf clean all
+RUN dnf -y install xorg-x11-server-Xvfb libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel libXi-devel mesa-libGL-devel alsa-lib-devel pulseaudio-libs-devel freetype-devel openssl-devel libudev-devel mesa-libGLU-devel mesa-dri-drivers && dnf clean all
 
 CMD ['/bin/bash']

--- a/Dockerfile.mono-glue
+++ b/Dockerfile.mono-glue
@@ -2,6 +2,6 @@ ARG mono_version
 FROM godot-mono:${mono_version}
 ARG mono_version
 
-RUN dnf -y install xorg-x11-server-Xvfb libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel libXi-devel mesa-libGL-devel alsa-lib-devel pulseaudio-libs-devel freetype-devel openssl-devel libudev-devel mesa-libGLU-devel mesa-dri-drivers && dnf clean all
+RUN dnf -y install xorg-x11-server-Xvfb libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel libXi-devel mesa-libGL-devel alsa-lib-devel pulseaudio-libs-devel libudev-devel mesa-libGLU-devel mesa-dri-drivers && dnf clean all
 
 CMD ['/bin/bash']

--- a/Dockerfile.msvc
+++ b/Dockerfile.msvc
@@ -1,7 +1,7 @@
 FROM godot-fedora:latest
 
 ENV WINEDEBUG=-all
-RUN dnf -y install wine winetricks xorg-x11-server-Xvfb curl p7zip-plugins findutils && dnf clean all && \
+RUN dnf -y install wine winetricks xorg-x11-server-Xvfb p7zip-plugins findutils && dnf clean all && \
     curl -LO https://github.com/GodotBuilder/godot-builds/releases/download/_tools/angle.7z && \
     curl -LO https://www.python.org/ftp/python/3.7.2/python-3.7.2-amd64.exe && \
     xvfb-run sh -c "winetricks -q vcrun2017; wineserver -w" ;\

--- a/Dockerfile.msvc
+++ b/Dockerfile.msvc
@@ -1,7 +1,9 @@
 FROM godot-fedora:latest
 
 ENV WINEDEBUG=-all
-RUN dnf -y install wine winetricks xorg-x11-server-Xvfb p7zip-plugins findutils && dnf clean all && \
+RUN dnf -y install --setopt=install_weak_deps=False \
+      wine winetricks xorg-x11-server-Xvfb p7zip-plugins findutils && \
+    dnf clean all && \
     curl -LO https://github.com/GodotBuilder/godot-builds/releases/download/_tools/angle.7z && \
     curl -LO https://www.python.org/ftp/python/3.7.2/python-3.7.2-amd64.exe && \
     xvfb-run sh -c "winetricks -q vcrun2017; wineserver -w" ;\

--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -4,7 +4,7 @@ ARG mono_version
 
 RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi
 
-RUN dnf -y install automake autoconf bzip2-devel clang git libicu-devel libtool libxml2-devel llvm-devel make openssl-devel patch scons xz bzip2 yasm && dnf clean all && \
+RUN dnf -y install automake autoconf bzip2-devel clang libicu-devel libtool libxml2-devel llvm-devel openssl-devel yasm && dnf clean all && \
     git clone https://github.com/tpoechtrager/osxcross.git && \
     cd /root/osxcross && \
     ln -s /root/files/MacOSX10.14.sdk.tar.xz /root/osxcross/tarballs && \

--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -4,7 +4,9 @@ ARG mono_version
 
 RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi
 
-RUN dnf -y install automake autoconf bzip2-devel clang libicu-devel libtool libxml2-devel llvm-devel openssl-devel yasm && dnf clean all && \
+RUN dnf -y install --setopt=install_weak_deps=False \
+      automake autoconf bzip2-devel clang libicu-devel libtool libxml2-devel llvm-devel openssl-devel yasm && \
+    dnf clean all && \
     git clone https://github.com/tpoechtrager/osxcross.git && \
     cd /root/osxcross && \
     ln -s /root/files/MacOSX10.14.sdk.tar.xz /root/osxcross/tarballs && \

--- a/Dockerfile.ubuntu-32
+++ b/Dockerfile.ubuntu-32
@@ -11,10 +11,11 @@ RUN apt-get update && \
     wget -O- 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x8E51A6D660CD88D67D65221D90BD7EACED8E640A' | apt-key add - && \
     echo 'deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu trusty main' >> /etc/apt/sources.list && \
     echo 'deb http://ppa.launchpad.net/mc3man/trusty-media/ubuntu trusty main' >> /etc/apt/sources.list && \
-    apt-get update && \
-    apt-get install -y bzip2 cmake curl git make perl scons xz-utils && \
-    apt-get install -y gcc-8 g++-8 libudev-dev libx11-dev libxcursor-dev libxrandr-dev libasound2-dev libpulse-dev \
-            libgl1-mesa-dev libglu1-mesa-dev libxi-dev libxinerama-dev yasm && \
+    apt-get -y update && \
+    apt-get -y install --no-install-recommends \
+      autoconf automake bzip2 cmake curl gettext git libtool make perl scons xz-utils \
+      gcc-8 g++-8 libudev-dev libx11-dev libxcursor-dev libxrandr-dev libasound2-dev libpulse-dev \
+      libgl1-mesa-dev libglu1-mesa-dev libxi-dev libxinerama-dev yasm && \
     ln -sf /usr/bin/gcc-ranlib-8 /usr/bin/gcc-ranlib && \
     ln -sf /usr/bin/gcc-ar-8 /usr/bin/gcc-ar && \
     ln -sf /usr/bin/gcc-8 /usr/bin/gcc && \

--- a/Dockerfile.ubuntu-32
+++ b/Dockerfile.ubuntu-32
@@ -14,7 +14,7 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y bzip2 cmake curl git make perl scons xz-utils && \
     apt-get install -y gcc-8 g++-8 libudev-dev libx11-dev libxcursor-dev libxrandr-dev libasound2-dev libpulse-dev \
-            libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev libxi-dev libxinerama-dev yasm && \
+            libgl1-mesa-dev libglu1-mesa-dev libxi-dev libxinerama-dev yasm && \
     ln -sf /usr/bin/gcc-ranlib-8 /usr/bin/gcc-ranlib && \
     ln -sf /usr/bin/gcc-ar-8 /usr/bin/gcc-ar && \
     ln -sf /usr/bin/gcc-8 /usr/bin/gcc && \

--- a/Dockerfile.ubuntu-32
+++ b/Dockerfile.ubuntu-32
@@ -12,8 +12,9 @@ RUN apt-get update && \
     echo 'deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu trusty main' >> /etc/apt/sources.list && \
     echo 'deb http://ppa.launchpad.net/mc3man/trusty-media/ubuntu trusty main' >> /etc/apt/sources.list && \
     apt-get update && \
+    apt-get install -y bzip2 cmake curl git make perl scons xz-utils && \
     apt-get install -y gcc-8 g++-8 libudev-dev libx11-dev libxcursor-dev libxrandr-dev libasound2-dev libpulse-dev \
-            libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev libxi-dev libxinerama-dev git scons cmake perl make curl bzip2 xz-utils yasm && \
+            libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev libxi-dev libxinerama-dev yasm && \
     ln -sf /usr/bin/gcc-ranlib-8 /usr/bin/gcc-ranlib && \
     ln -sf /usr/bin/gcc-ar-8 /usr/bin/gcc-ar && \
     ln -sf /usr/bin/gcc-8 /usr/bin/gcc && \

--- a/Dockerfile.ubuntu-64
+++ b/Dockerfile.ubuntu-64
@@ -11,10 +11,11 @@ RUN apt-get update && \
     wget -O- 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x8E51A6D660CD88D67D65221D90BD7EACED8E640A' | apt-key add - && \
     echo 'deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu trusty main' >> /etc/apt/sources.list && \
     echo 'deb http://ppa.launchpad.net/mc3man/trusty-media/ubuntu trusty main' >> /etc/apt/sources.list && \
-    apt-get update && \
-    apt-get install -y bzip2 cmake curl git make perl scons xz-utils && \
-    apt-get install -y gcc-8 g++-8 libudev-dev libx11-dev libxcursor-dev libxrandr-dev libasound2-dev libpulse-dev \
-            libgl1-mesa-dev libglu1-mesa-dev libxi-dev libxinerama-dev yasm && \
+    apt-get -y update && \
+    apt-get -y install --no-install-recommends \
+      autoconf automake bzip2 cmake curl gettext git libtool make perl scons xz-utils \
+      gcc-8 g++-8 libudev-dev libx11-dev libxcursor-dev libxrandr-dev libasound2-dev libpulse-dev \
+      libgl1-mesa-dev libglu1-mesa-dev libxi-dev libxinerama-dev yasm && \
     ln -sf /usr/bin/gcc-ranlib-8 /usr/bin/gcc-ranlib && \
     ln -sf /usr/bin/gcc-ar-8 /usr/bin/gcc-ar && \
     ln -sf /usr/bin/gcc-8 /usr/bin/gcc && \

--- a/Dockerfile.ubuntu-64
+++ b/Dockerfile.ubuntu-64
@@ -14,7 +14,7 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y bzip2 cmake curl git make perl scons xz-utils && \
     apt-get install -y gcc-8 g++-8 libudev-dev libx11-dev libxcursor-dev libxrandr-dev libasound2-dev libpulse-dev \
-            libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev libxi-dev libxinerama-dev yasm && \
+            libgl1-mesa-dev libglu1-mesa-dev libxi-dev libxinerama-dev yasm && \
     ln -sf /usr/bin/gcc-ranlib-8 /usr/bin/gcc-ranlib && \
     ln -sf /usr/bin/gcc-ar-8 /usr/bin/gcc-ar && \
     ln -sf /usr/bin/gcc-8 /usr/bin/gcc && \

--- a/Dockerfile.ubuntu-64
+++ b/Dockerfile.ubuntu-64
@@ -12,8 +12,9 @@ RUN apt-get update && \
     echo 'deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu trusty main' >> /etc/apt/sources.list && \
     echo 'deb http://ppa.launchpad.net/mc3man/trusty-media/ubuntu trusty main' >> /etc/apt/sources.list && \
     apt-get update && \
+    apt-get install -y bzip2 cmake curl git make perl scons xz-utils && \
     apt-get install -y gcc-8 g++-8 libudev-dev libx11-dev libxcursor-dev libxrandr-dev libasound2-dev libpulse-dev \
-            libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev libxi-dev libxinerama-dev git scons cmake perl make curl bzip2 xz-utils yasm && \
+            libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev libxi-dev libxinerama-dev yasm && \
     ln -sf /usr/bin/gcc-ranlib-8 /usr/bin/gcc-ranlib && \
     ln -sf /usr/bin/gcc-ar-8 /usr/bin/gcc-ar && \
     ln -sf /usr/bin/gcc-8 /usr/bin/gcc && \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -4,7 +4,7 @@ ARG mono_version
 
 RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi
 
-RUN dnf -y install scons mingw32-gcc mingw32-gcc-c++ mingw32-winpthreads-static mingw64-gcc mingw64-gcc-c++ mingw64-winpthreads-static yasm bzip2 xz && dnf clean all && \
+RUN dnf -y install mingw32-gcc mingw32-gcc-c++ mingw32-winpthreads-static mingw64-gcc mingw64-gcc-c++ mingw64-winpthreads-static yasm && dnf clean all && \
     rpm -Uvh --force /root/files/mingw-binutils-generic-2.30-5.fc29.godot.x86_64.rpm \
                      /root/files/mingw64-binutils-2.30-5.fc29.godot.x86_64.rpm \
                      /root/files/mingw32-binutils-2.30-5.fc29.godot.x86_64.rpm && \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -4,7 +4,9 @@ ARG mono_version
 
 RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi
 
-RUN dnf -y install mingw32-gcc mingw32-gcc-c++ mingw32-winpthreads-static mingw64-gcc mingw64-gcc-c++ mingw64-winpthreads-static yasm && dnf clean all && \
+RUN dnf -y install --setopt=install_weak_deps=False \
+      mingw32-gcc mingw32-gcc-c++ mingw32-winpthreads-static mingw64-gcc mingw64-gcc-c++ mingw64-winpthreads-static yasm && \
+    dnf clean all && \
     rpm -Uvh --force /root/files/mingw-binutils-generic-2.30-5.fc29.godot.x86_64.rpm \
                      /root/files/mingw64-binutils-2.30-5.fc29.godot.x86_64.rpm \
                      /root/files/mingw32-binutils-2.30-5.fc29.godot.x86_64.rpm && \

--- a/Dockerfile.xcode
+++ b/Dockerfile.xcode
@@ -1,6 +1,8 @@
 FROM godot-fedora:latest
 
-RUN dnf -y install autoconf automake libtool clang cmake fuse fuse-devel libxml2-devel libicu-devel compat-openssl10-devel bzip2-devel kmod cpio && \
+RUN dnf -y install --setopt=install_weak_deps=False \
+      autoconf automake libtool clang cmake fuse fuse-devel libxml2-devel libicu-devel compat-openssl10-devel bzip2-devel kmod cpio && \
+    dnf clean all && \
     git clone https://github.com/mackyle/xar.git && \
     cd xar/xar && \
     ./autogen.sh --prefix=/usr && \

--- a/Dockerfile.xcode
+++ b/Dockerfile.xcode
@@ -1,6 +1,6 @@
 FROM godot-fedora:latest
 
-RUN dnf -y install autoconf automake libtool clang cmake fuse fuse-devel git patch make libxml2-devel libicu-devel compat-openssl10-devel bzip2-devel kmod xz cpio && \
+RUN dnf -y install autoconf automake libtool clang cmake fuse fuse-devel libxml2-devel libicu-devel compat-openssl10-devel bzip2-devel kmod cpio && \
     git clone https://github.com/mackyle/xar.git && \
     cd xar/xar && \
     ./autogen.sh --prefix=/usr && \


### PR DESCRIPTION
Since we need to install those deps in most leaf containers, I figure it might be better to simply get them in the base one.

We can discuss whether all those should be included in the base or if some should be left in leaf containers, as well as whether we want to include more stuff in the base container (perl? nano? :P).

We also have a couple containers installing `python`, but I'm not sure it's really needed. We should likely aim for being python3-only (see also #13).