### PR TITLE
Use git tag to checkout stable mono releases

### DIFF
--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -2,7 +2,8 @@ ARG mono_version
 FROM godot-mono:${mono_version}
 ARG mono_version
 
-RUN dnf -y install --setopt=install_weak_deps=False \
+RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
+    dnf -y install --setopt=install_weak_deps=False \
       gcc gcc-c++ java-1.8.0-openjdk-devel ncurses-compat-libs && \
     dnf clean all && \
     mkdir sdk && cd sdk && \
@@ -10,8 +11,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     unzip sdk-tools-linux-4333796.zip && \
     rm sdk-tools-linux-4333796.zip && \
     yes | tools/bin/sdkmanager --licenses && \
-    tools/bin/sdkmanager ndk-bundle 'build-tools;28.0.3' 'platforms;android-28' 'cmake;3.10.2.4988404' && \
-    cd ..
+    tools/bin/sdkmanager ndk-bundle 'build-tools;28.0.3' 'platforms;android-28' 'cmake;3.10.2.4988404'
 
 ENV ANDROID_HOME=/root/sdk/
 ENV ANDROID_NDK_ROOT=/root/sdk/ndk-bundle/

--- a/Dockerfile.mono
+++ b/Dockerfile.mono
@@ -2,25 +2,20 @@ FROM godot-fedora:latest
 
 ARG mono_version
 
-RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi
-
-RUN dnf -y install --setopt=install_weak_deps=False \
-      autoconf automake cmake gettext gcc gcc-c++ libtool perl python && \
+RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
+    dnf -y install --setopt=install_weak_deps=False \
+      autoconf automake cmake gcc gcc-c++ gettext libtool perl python && \
     dnf clean all && \
-    if [ ${mono_version%%.*} -ge 6 ]; then \
-        curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.xz | tar xJ; \
-    else \
-        curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.bz2 | tar xj; \
-    fi && \
-    cd mono-${mono_version} && \
-    autoreconf -vfi && \
+    git clone https://github.com/mono/mono --branch mono-${mono_version} --single-branch && \
+    cd mono && git submodule update --init && \
+    NOCONFIGURE=1 ./autogen.sh && \
     ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var/lib/mono --disable-boehm && \
-    make -j && make install && \
-    cd /root && \
-    rm -rf mono-${mono_version} && \
-    cert-sync /etc/pki/tls/certs/ca-bundle.crt
-
-RUN rpm -ivh --nodeps https://download.mono-project.com/repo/centos8-stable/m/msbuild/msbuild-16.0+xamarinxplat.2018.09.26.17.53-0.xamarin.5.epel8.noarch.rpm \
+    make -j && \
+    make install && \
+    cd .. && \
+    cert-sync /etc/pki/tls/certs/ca-bundle.crt && \
+    rpm -ivh --nodeps https://download.mono-project.com/repo/centos8-stable/m/msbuild/msbuild-16.0+xamarinxplat.2018.09.26.17.53-0.xamarin.5.epel8.noarch.rpm \
                       https://download.mono-project.com/repo/centos8-stable/m/msbuild-libhostfxr/msbuild-libhostfxr-2.0.0.2017.07.06.00.01-0.xamarin.3.epel8.x86_64.rpm \
                       https://download.mono-project.com/repo/centos8-stable/m/msbuild/msbuild-sdkresolver-16.0+xamarinxplat.2018.09.26.17.53-0.xamarin.5.epel8.noarch.rpm \
-                      https://download.mono-project.com/repo/centos8-stable/n/nuget/nuget-4.7.0.5148.bin-0.xamarin.2.epel8.noarch.rpm
+                      https://download.mono-project.com/repo/centos8-stable/n/nuget/nuget-4.7.0.5148.bin-0.xamarin.2.epel8.noarch.rpm && \
+    rm -rf /root/mono

--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -2,9 +2,8 @@ ARG mono_version
 FROM godot-mono:${mono_version}
 ARG mono_version
 
-RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi
-
-RUN dnf -y install --setopt=install_weak_deps=False \
+RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
+    dnf -y install --setopt=install_weak_deps=False \
       automake autoconf bzip2-devel clang libicu-devel libtool libxml2-devel llvm-devel openssl-devel yasm && \
     dnf clean all && \
     git clone https://github.com/tpoechtrager/osxcross.git && \
@@ -32,15 +31,11 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     cp -v /root/osxcross/build/compiler-rt/build/lib/darwin/*.a ${CLANG_LIB_DIR}/lib/darwin && \
     cp -v /root/osxcross/build/compiler-rt/build/lib/darwin/*.dylib ${CLANG_LIB_DIR}/lib/darwin
 
-RUN if [ ${mono_version%%.*} -ge 6 ]; then \
-        curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.xz | tar xJ; \
-    else \
-        curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.bz2 | tar xj; \
-    fi && \
-    cd mono-${mono_version} && \
+RUN git clone https://github.com/mono/mono --branch mono-${mono_version} --single-branch && \
+    cd mono && git submodule update --init && \
     patch -p1 < /root/files/patches/fix-mono-configure.diff && \
     export PATH=/root/osxcross/target/bin:$PATH && \
-    export CMAKE=/root//osxcross/target/bin/x86_64-apple-darwin17-cmake && \
+    export CMAKE=/root/osxcross/target/bin/x86_64-apple-darwin17-cmake && \
     ./autogen.sh --prefix=/root/dependencies/mono \
         --build=x86_64-linux-gnu \
         --host=x86_64-apple-darwin17 \
@@ -55,13 +50,14 @@ RUN if [ ${mono_version%%.*} -ge 6 ]; then \
         CXX=o64-clang++ && \
     make -j && \
     make install && \
+    cd .. && \
     rm -f /root/dependencies/mono/bin/mono /root/dependencies/mono/bin/mono-sgen && \
     ln -s /usr/bin/mono /root/dependencies/mono/bin/mono && \
     ln -s /usr/bin/mono-sgen /root/dependencies/mono/bin/mono-sgen && \
-    ln -sf /usr/lib/mono/* /root/dependencies/mono/lib/mono ;\
+    ln -sf /usr/lib/mono/* /root/dependencies/mono/lib/mono && \
     cp -rvp /etc/mono /root/dependencies/mono/etc && \
     cp /root/files/mono-config-macosx /root/dependencies/mono/etc/config && \
-    rm -rf /root/mono-${mono_version} /root/apple-libtapi /root/cctools-port
+    rm -rf /root/mono /root/apple-libtapi /root/cctools-port
 
 ENV MONO64_PREFIX=/root/dependencies/mono
 ENV OSXCROSS_ROOT=/root/osxcross

--- a/Dockerfile.ubuntu-32
+++ b/Dockerfile.ubuntu-32
@@ -2,9 +2,8 @@ FROM i386/ubuntu:trusty
 
 ARG mono_version
 
-RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi
-
-RUN apt-get update && \
+RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
+    apt-get update && \
     apt-get -y install wget && \
     cd /root && \
     wget -O- 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F' | apt-key add - && \
@@ -19,16 +18,15 @@ RUN apt-get update && \
     ln -sf /usr/bin/gcc-ranlib-8 /usr/bin/gcc-ranlib && \
     ln -sf /usr/bin/gcc-ar-8 /usr/bin/gcc-ar && \
     ln -sf /usr/bin/gcc-8 /usr/bin/gcc && \
-    ln -sf /usr/bin/g++-8 /usr/bin/g++ && \
-    if [ ${mono_version%%.*} -ge 6 ]; then \
-        curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.xz | tar xJ; \
-    else \
-        curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.bz2 | tar xj; \
-    fi && \
-    cd mono-${mono_version} && \
+    ln -sf /usr/bin/g++-8 /usr/bin/g++
+
+RUN git clone https://github.com/mono/mono --branch mono-${mono_version} --single-branch && \
+    cd mono && git submodule update --init && \
+    NOCONFIGURE=1 ./autogen.sh && \
     ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var/lib/mono --disable-boehm --host=i386-linux-gnu && \
     make -j && \
     make install && \
+    cd .. && \
     cert-sync /etc/ssl/certs/ca-certificates.crt && \
     wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild_16.0+xamarinxplat.2018.09.26.17.53-0xamarin3+ubuntu1404b1_all.deb && \
     wget https://download.mono-project.com/repo/ubuntu/pool/main/c/core-setup/msbuild-libhostfxr_2.0.0.2017.07.06.00.01-0xamarin21+ubuntu1404b1_i386.deb && \
@@ -40,6 +38,6 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/ && \
     rm *.deb && \
-    rm -rf /root/mono-${mono_version}
+    rm -rf /root/mono
 
 CMD ['/bin/bash']

--- a/Dockerfile.ubuntu-64
+++ b/Dockerfile.ubuntu-64
@@ -2,9 +2,8 @@ FROM ubuntu:trusty
 
 ARG mono_version
 
-RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi
-
-RUN apt-get update && \
+RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
+    apt-get update && \
     apt-get -y install wget && \
     cd /root && \
     wget -O- 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F' | apt-key add - && \
@@ -19,16 +18,15 @@ RUN apt-get update && \
     ln -sf /usr/bin/gcc-ranlib-8 /usr/bin/gcc-ranlib && \
     ln -sf /usr/bin/gcc-ar-8 /usr/bin/gcc-ar && \
     ln -sf /usr/bin/gcc-8 /usr/bin/gcc && \
-    ln -sf /usr/bin/g++-8 /usr/bin/g++ && \
-    if [ ${mono_version%%.*} -ge 6 ]; then \
-        curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.xz | tar xJ; \
-    else \
-        curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.bz2 | tar xj; \
-    fi && \
-    cd mono-${mono_version} && \
+    ln -sf /usr/bin/g++-8 /usr/bin/g++
+
+RUN git clone https://github.com/mono/mono --branch mono-${mono_version} --single-branch && \
+    cd mono && git submodule update --init && \
+    NOCONFIGURE=1 ./autogen.sh && \
     ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var/lib/mono --disable-boehm --host=x86_64-linux-gnu && \
     make -j && \
     make install && \
+    cd .. && \
     cert-sync /etc/ssl/certs/ca-certificates.crt && \
     wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild_16.0+xamarinxplat.2018.09.26.17.53-0xamarin3+ubuntu1404b1_all.deb && \
     wget https://download.mono-project.com/repo/ubuntu/pool/main/c/core-setup/msbuild-libhostfxr_2.0.0.2017.07.06.00.01-0xamarin21+ubuntu1404b1_amd64.deb && \
@@ -40,6 +38,6 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/ && \
     rm *.deb && \
-    rm -rf /root/mono-${mono_version}
+    rm -rf /root/mono
 
 CMD ['/bin/bash']

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -2,47 +2,41 @@ ARG mono_version
 FROM godot-mono:${mono_version}
 ARG mono_version
 
-RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi
-
-RUN dnf -y install --setopt=install_weak_deps=False \
+RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
+    dnf -y install --setopt=install_weak_deps=False \
       mingw32-gcc mingw32-gcc-c++ mingw32-winpthreads-static mingw64-gcc mingw64-gcc-c++ mingw64-winpthreads-static yasm && \
     dnf clean all && \
     rpm -Uvh --force /root/files/mingw-binutils-generic-2.30-5.fc29.godot.x86_64.rpm \
                      /root/files/mingw64-binutils-2.30-5.fc29.godot.x86_64.rpm \
-                     /root/files/mingw32-binutils-2.30-5.fc29.godot.x86_64.rpm && \
-    if [ ${mono_version%%.*} -ge 6 ]; then \
-        curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.xz | tar xJ; \
-    else \
-        curl https://download.mono-project.com/sources/mono/mono-${mono_version}.tar.bz2 | tar xj; \
-    fi && \
-    cp -r mono-${mono_version} mono-${mono_version}-32 && \
-    cd mono-${mono_version} && \
+                     /root/files/mingw32-binutils-2.30-5.fc29.godot.x86_64.rpm
+
+RUN git clone https://github.com/mono/mono --branch mono-${mono_version} --single-branch && \
+    cd mono && git submodule update --init && \
+    NOCONFIGURE=1 ./autogen.sh && \
     ./configure --prefix=/root/dependencies/mono-64 --host=x86_64-w64-mingw32 --disable-boehm --disable-mcs-build --disable-executables && \
     echo '#define HAVE_STRUCT_SOCKADDR_IN6 1' >> config.h && \
     make -j && \
     make install && \
-    cd .. && \
-    rm -rf mono-${mono_version} && \
+    git clean -fdx && \
     cp /root/dependencies/mono-64/bin/libMonoPosixHelper.dll /root/dependencies/mono-64/bin/MonoPosixHelper.dll && \
     rm -f /root/dependencies/mono-64/bin/mono /root/dependencies/mono-64/bin/mono-sgen && \
     ln -s /usr/bin/mono /root/dependencies/mono-64/bin/mono && \
     ln -s /usr/bin/mono-sgen /root/dependencies/mono-64/bin/mono-sgen && \
     ln -sf /usr/lib/mono/* /root/dependencies/mono-64/lib/mono || /bin/true && \
-    cp -rvp /etc/mono /root/dependencies/mono-64/etc
-
-RUN cd mono-${mono_version}-32 && \
+    cp -rvp /etc/mono /root/dependencies/mono-64/etc && \
+    NOCONFIGURE=1 ./autogen.sh && \
     ./configure --prefix=/root/dependencies/mono-32 --host=i686-w64-mingw32 --disable-boehm --disable-mcs-build --disable-executables && \
     echo '#define HAVE_STRUCT_SOCKADDR_IN6 1' >> config.h && \
     make -j && \
     make install && \
     cd .. && \
-    rm -rf mono-${mono_version}-32 && \
     cp /root/dependencies/mono-32/bin/libMonoPosixHelper.dll /root/dependencies/mono-32/bin/MonoPosixHelper.dll && \
     rm -f /root/dependencies/mono-32/bin/mono /root/dependencies/mono-32/bin/mono-sgen && \
     ln -s /usr/bin/mono /root/dependencies/mono-32/bin/mono && \
     ln -s /usr/bin/mono-sgen /root/dependencies/mono-32/bin/mono-sgen && \
     ln -sf /usr/lib/mono/* /root/dependencies/mono-32/lib/mono || /bin/true && \
-    cp -rvp /etc/mono /root/dependencies/mono-32/etc
+    cp -rvp /etc/mono /root/dependencies/mono-32/etc && \
+    rm -rf /root/mono
 
 ENV MONO32_PREFIX=/root/dependencies/mono-32
 ENV MONO64_PREFIX=/root/dependencies/mono-64


### PR DESCRIPTION
The main reason is that upstream Mono tends to miss some
important files in its tarballs, so Git tags appears to be
a more reliable medium.

Also split RUN further to do cleanup in a separate stage,
allowing to inspect intermediary images to debug build or
packaging issues.

---

**Depends on #16.**

Includes commits from #16, I'll rebase once that first PR is merged.

Only the last commit in this PR is meant to be reviewed here.