### PR TITLE
Use /bin/bash as default CMD, log container build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 *.dmg
 *.zip
 *.xip
+
+logs/

--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -31,4 +31,4 @@ RUN git clone https://github.com/mono/mono --branch mono-${mono_version} --singl
     cd .. && \
     rm -rf /root/mono /root/godot-mono-builds
 
-CMD ['/bin/bash']
+CMD /bin/bash

--- a/Dockerfile.export
+++ b/Dockerfile.export
@@ -4,4 +4,4 @@ RUN dnf -y install --setopt=install_weak_deps=False \
       xorg-x11-server-Xvfb mesa-dri-drivers libXcursor libXinerama libXrandr libXi alsa-lib pulseaudio-libs java-1.8.0-openjdk-devel && \
     dnf clean all
 
-CMD ['/bin/bash']
+CMD /bin/bash

--- a/Dockerfile.ios
+++ b/Dockerfile.ios
@@ -20,4 +20,4 @@ RUN dnf -y install --setopt=install_weak_deps=False \
 
 ENV OSXCROSS_IOS=not_nothing
 
-CMD ['/bin/bash']
+CMD /bin/bash

--- a/Dockerfile.javascript
+++ b/Dockerfile.javascript
@@ -26,4 +26,4 @@ RUN git clone https://github.com/mono/mono --branch mono-${mono_version} --singl
     cd .. && \
     rm -rf /root/mono /root/godot-mono-builds
 
-CMD ['/bin/bash']
+CMD /bin/bash

--- a/Dockerfile.mono
+++ b/Dockerfile.mono
@@ -19,3 +19,5 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
                       https://download.mono-project.com/repo/centos8-stable/m/msbuild/msbuild-sdkresolver-16.0+xamarinxplat.2018.09.26.17.53-0.xamarin.5.epel8.noarch.rpm \
                       https://download.mono-project.com/repo/centos8-stable/n/nuget/nuget-4.7.0.5148.bin-0.xamarin.2.epel8.noarch.rpm && \
     rm -rf /root/mono
+
+CMD /bin/bash

--- a/Dockerfile.mono-glue
+++ b/Dockerfile.mono-glue
@@ -6,4 +6,4 @@ RUN dnf -y install --setopt=install_weak_deps=False \
       xorg-x11-server-Xvfb libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel libXi-devel alsa-lib-devel pulseaudio-libs-devel libudev-devel mesa-libGL-devel mesa-libGLU-devel mesa-dri-drivers && \
     dnf clean all
 
-CMD ['/bin/bash']
+CMD /bin/bash

--- a/Dockerfile.msvc
+++ b/Dockerfile.msvc
@@ -25,4 +25,4 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     rm -rf /root/.wine/drive_c/users/root/Temp/* && \
     rm -rf /root/.cache
     
-CMD /usr/bin/bash
+CMD /bin/bash

--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -62,4 +62,4 @@ RUN git clone https://github.com/mono/mono --branch mono-${mono_version} --singl
 ENV MONO64_PREFIX=/root/dependencies/mono
 ENV OSXCROSS_ROOT=/root/osxcross
 
-CMD ['/bin/bash']
+CMD /bin/bash

--- a/Dockerfile.ubuntu-32
+++ b/Dockerfile.ubuntu-32
@@ -40,4 +40,4 @@ RUN git clone https://github.com/mono/mono --branch mono-${mono_version} --singl
     rm *.deb && \
     rm -rf /root/mono
 
-CMD ['/bin/bash']
+CMD /bin/bash

--- a/Dockerfile.ubuntu-64
+++ b/Dockerfile.ubuntu-64
@@ -40,4 +40,4 @@ RUN git clone https://github.com/mono/mono --branch mono-${mono_version} --singl
     rm *.deb && \
     rm -rf /root/mono
 
-CMD ['/bin/bash']
+CMD /bin/bash

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -41,4 +41,4 @@ RUN git clone https://github.com/mono/mono --branch mono-${mono_version} --singl
 ENV MONO32_PREFIX=/root/dependencies/mono-32
 ENV MONO64_PREFIX=/root/dependencies/mono-64
 
-CMD ['/bin/bash']
+CMD /bin/bash

--- a/Dockerfile.xcode
+++ b/Dockerfile.xcode
@@ -36,4 +36,3 @@ CMD mkdir -p /root/xcode && \
     cp -r Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1 /tmp/iPhoneOS12.4.sdk/usr/include/c++ && \
     cd /tmp && \
     tar -cJf /root/files/iPhoneSimulator12.4.sdk.tar.xz iPhoneOS12.4.sdk
-


### PR DESCRIPTION
The previous `['/bin/bash']` was not working, running the image
with `podman run -it <name>` would evaluate to:
```
> sh -c ['/bin/bash']
sh: [/bin/bash]: No such file or directory
```