### PR TITLE
OSX: Fix support for latest osxcross and Xcode 10.13

### DIFF
--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -8,37 +8,20 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
     dnf clean all && \
     git clone https://github.com/tpoechtrager/osxcross.git && \
     cd /root/osxcross && \
+    git checkout 542acc2ef6c21aeb3f109c03748b1015a71fed63 && \
     ln -s /root/files/MacOSX10.14.sdk.tar.xz /root/osxcross/tarballs && \
-    UNATTENDED=1 ./build.sh ;\
-    cd /root && \
-    git clone https://github.com/tpoechtrager/apple-libtapi.git && \
-    cd apple-libtapi && \
-    INSTALLPREFIX=/root/osxcross/target ./build.sh && ./install.sh && \
-    cd /root && \
-    git clone https://github.com/tpoechtrager/cctools-port.git && \
-    cd cctools-port/cctools/ && \
-    ./configure --prefix=/root/osxcross/target --target=x86_64-apple-darwin17 --with-libtapi=/root/osxcross/target && \
-    make -j && make install && \
-    cd /root && \
-    ln -fs /root/osxcross/target/bin/x86_64-apple-darwin17-install_name_tool /root/osxcross/target/bin/install_name_tool && \
-    ln -fs /root/osxcross/target/bin/x86_64-apple-darwin17-ar /root/osxcross/target/bin/ar && \
-    cd /root/osxcross/ && \
-    ./build_compiler_rt.sh && \
-    export CLANG_LIB_DIR=$(clang -print-search-dirs | grep "libraries: =" | tr '=' ' ' | tr ':' ' ' | awk '{print $2}') && \
-    mkdir -p ${CLANG_LIB_DIR}/include && \
-    mkdir -p ${CLANG_LIB_DIR}/lib/darwin && \
-    cp -rv /root/osxcross/build/compiler-rt/include/sanitizer ${CLANG_LIB_DIR}/include && \
-    cp -v /root/osxcross/build/compiler-rt/build/lib/darwin/*.a ${CLANG_LIB_DIR}/lib/darwin && \
-    cp -v /root/osxcross/build/compiler-rt/build/lib/darwin/*.dylib ${CLANG_LIB_DIR}/lib/darwin
+    UNATTENDED=1 ./build.sh
+
+ENV OSXCROSS_ROOT=/root/osxcross
+ENV PATH="/root/osxcross/target/bin:${PATH}"
 
 RUN git clone https://github.com/mono/mono --branch mono-${mono_version} --single-branch && \
     cd mono && git submodule update --init && \
-    patch -p1 < /root/files/patches/fix-mono-configure.diff && \
-    export PATH=/root/osxcross/target/bin:$PATH && \
-    export CMAKE=/root/osxcross/target/bin/x86_64-apple-darwin17-cmake && \
-    ./autogen.sh --prefix=/root/dependencies/mono \
+    export CMAKE=/root/osxcross/target/bin/x86_64-apple-darwin18-cmake && \
+    NOCONFIGURE=1 ./autogen.sh && \
+    ./configure --prefix=/root/dependencies/mono \
         --build=x86_64-linux-gnu \
-        --host=x86_64-apple-darwin17 \
+        --host=x86_64-apple-darwin18 \
         --disable-boehm \
         --disable-mcs-build \
         --with-tls=pthread \
@@ -57,9 +40,8 @@ RUN git clone https://github.com/mono/mono --branch mono-${mono_version} --singl
     ln -sf /usr/lib/mono/* /root/dependencies/mono/lib/mono && \
     cp -rvp /etc/mono /root/dependencies/mono/etc && \
     cp /root/files/mono-config-macosx /root/dependencies/mono/etc/config && \
-    rm -rf /root/mono /root/apple-libtapi /root/cctools-port
+    rm -rf /root/mono
 
 ENV MONO64_PREFIX=/root/dependencies/mono
-ENV OSXCROSS_ROOT=/root/osxcross
 
 CMD /bin/bash

--- a/Dockerfile.xcode
+++ b/Dockerfile.xcode
@@ -17,22 +17,25 @@ CMD mkdir -p /root/xcode && \
     xar -xf /root/files/Xcode_10.3.xip && \
     /root/pbzx/pbzx -n Content | cpio -i && \
     cp -r Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk /tmp/MacOSX10.14.sdk && \
-    cp -r Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1 /tmp/MacOSX10.14.sdk/usr/include/c++ && \
+    mkdir -p /tmp/MacOSX10.14.sdk/usr/include/c++ && \
+    cp -r Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1 /tmp/MacOSX10.14.sdk/usr/include/c++/ && \
     mkdir -p mkdir -p /tmp/MacOSX10.14.sdk/usr/share/man && \
     cp -rf Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/share/man/man1 \
            Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/share/man/man3 \
-           Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/share/man/man5 /tmp/MacOSX10.14.sdk/usr/share/man && \
+           Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/share/man/man5 /tmp/MacOSX10.14.sdk/usr/share/man/ && \
     cd /tmp && \
     tar -cJf /root/files/MacOSX10.14.sdk.tar.xz MacOSX10.14.sdk && \
     rm -rf MacOSX10.14 && \
     cd /root/xcode && \
     cp -r Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk /tmp/iPhoneOS12.4.sdk && \
-    cp -r Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1 /tmp/iPhoneOS12.4.sdk/usr/include/c++ && \
+    mkdir -p /tmp/iPhoneOS12.4.sdk/usr/include/c++ && \
+    cp -r Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1 /tmp/iPhoneOS12.4.sdk/usr/include/c++/ && \
     cd /tmp && \
     tar -cJf /root/files/iPhoneOS12.4.sdk.tar.xz iPhoneOS12.4.sdk && \
     rm -rf iPhoneOS12.4.sdk && \
     cd /root/xcode && \
     cp -r Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk /tmp/iPhoneOS12.4.sdk && \
-    cp -r Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1 /tmp/iPhoneOS12.4.sdk/usr/include/c++ && \
+    mkdir -p /tmp/iPhoneOS12.4.sdk/usr/include/c++ && \
+    cp -r Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1 /tmp/iPhoneOS12.4.sdk/usr/include/c++/ && \
     cd /tmp && \
     tar -cJf /root/files/iPhoneSimulator12.4.sdk.tar.xz iPhoneOS12.4.sdk


### PR DESCRIPTION
The osxcross installation process has been improved and now supports
more recent versions of Xcode than 7, so most of our custom code is
no longer needed.

The xcode packer could also be reworked to use osxcross' SDK packing
script.

Fixes #15.