### PR TITLE
mono: Update msbuild to 16.3, support for git branches

### DIFF
--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -16,9 +16,10 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
 ENV ANDROID_HOME=/root/sdk/
 ENV ANDROID_NDK_ROOT=/root/sdk/ndk-bundle/
 
-RUN git clone https://github.com/mono/mono --branch mono-${mono_version} --single-branch && \
+RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
     cd mono && git submodule update --init && cd .. && \
     export MONO_SOURCE_ROOT=/root/mono && \
+    export make="make -j" && \
     git clone https://github.com/godotengine/godot-mono-builds && \
     cd godot-mono-builds && \
     git checkout bd129da22b8b9c96f3e8b07af348cc5fb61504bf && \

--- a/Dockerfile.javascript
+++ b/Dockerfile.javascript
@@ -11,13 +11,15 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     ./emsdk activate 1.38.47-upstream && \
     echo "source /root/emsdk/emsdk_env.sh" >> /root/.bashrc
 
-RUN git clone https://github.com/mono/mono --branch mono-${mono_version} --single-branch && \
+RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
     cd mono && git submodule update --init && cd .. && \
     export MONO_SOURCE_ROOT=/root/mono && \
+    export make="make -j" && \
     git clone https://github.com/godotengine/godot-mono-builds && \
     cd godot-mono-builds && \
     git checkout bd129da22b8b9c96f3e8b07af348cc5fb61504bf && \
     python3 patch_emscripten.py && \
+    git am -3 /root/files/patches/mono-wasm-avoid-aligning-stack-bounds.patch && \
     python3 wasm.py configure --target=runtime && \
     python3 wasm.py make --target=runtime && \
     cd /root/mono && git clean -fdx && NOCONFIGURE=1 ./autogen.sh && \

--- a/Dockerfile.mono
+++ b/Dockerfile.mono
@@ -6,7 +6,7 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
     dnf -y install --setopt=install_weak_deps=False \
       autoconf automake cmake gcc gcc-c++ gettext libtool perl python && \
     dnf clean all && \
-    git clone https://github.com/mono/mono --branch mono-${mono_version} --single-branch && \
+    git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
     cd mono && git submodule update --init && \
     NOCONFIGURE=1 ./autogen.sh && \
     ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var/lib/mono --disable-boehm && \
@@ -14,10 +14,11 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
     make install && \
     cd .. && \
     cert-sync /etc/pki/tls/certs/ca-bundle.crt && \
-    rpm -ivh --nodeps https://download.mono-project.com/repo/centos8-stable/m/msbuild/msbuild-16.0+xamarinxplat.2018.09.26.17.53-0.xamarin.5.epel8.noarch.rpm \
-                      https://download.mono-project.com/repo/centos8-stable/m/msbuild-libhostfxr/msbuild-libhostfxr-2.0.0.2017.07.06.00.01-0.xamarin.3.epel8.x86_64.rpm \
-                      https://download.mono-project.com/repo/centos8-stable/m/msbuild/msbuild-sdkresolver-16.0+xamarinxplat.2018.09.26.17.53-0.xamarin.5.epel8.noarch.rpm \
-                      https://download.mono-project.com/repo/centos8-stable/n/nuget/nuget-4.7.0.5148.bin-0.xamarin.2.epel8.noarch.rpm && \
+    rpm -ivh --nodeps \
+      https://download.mono-project.com/repo/centos8-stable/m/msbuild/msbuild-16.3+xamarinxplat.2019.08.08.00.55-0.xamarin.2.epel8.noarch.rpm \
+      https://download.mono-project.com/repo/centos8-stable/m/msbuild-libhostfxr/msbuild-libhostfxr-3.0.0.2019.04.16.02.13-0.xamarin.4.epel8.x86_64.rpm \
+      https://download.mono-project.com/repo/centos8-stable/m/msbuild/msbuild-sdkresolver-16.3+xamarinxplat.2019.08.08.00.55-0.xamarin.2.epel8.noarch.rpm \
+      https://download.mono-project.com/repo/centos8-stable/n/nuget/nuget-5.2.0.6090.bin-0.xamarin.1.epel8.noarch.rpm && \
     rm -rf /root/mono
 
 CMD /bin/bash

--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -15,7 +15,7 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
 ENV OSXCROSS_ROOT=/root/osxcross
 ENV PATH="/root/osxcross/target/bin:${PATH}"
 
-RUN git clone https://github.com/mono/mono --branch mono-${mono_version} --single-branch && \
+RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
     cd mono && git submodule update --init && \
     export CMAKE=/root/osxcross/target/bin/x86_64-apple-darwin18-cmake && \
     NOCONFIGURE=1 ./autogen.sh && \

--- a/Dockerfile.ubuntu-32
+++ b/Dockerfile.ubuntu-32
@@ -20,7 +20,7 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
     ln -sf /usr/bin/gcc-8 /usr/bin/gcc && \
     ln -sf /usr/bin/g++-8 /usr/bin/g++
 
-RUN git clone https://github.com/mono/mono --branch mono-${mono_version} --single-branch && \
+RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
     cd mono && git submodule update --init && \
     NOCONFIGURE=1 ./autogen.sh && \
     ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var/lib/mono --disable-boehm --host=i386-linux-gnu && \
@@ -28,16 +28,16 @@ RUN git clone https://github.com/mono/mono --branch mono-${mono_version} --singl
     make install && \
     cd .. && \
     cert-sync /etc/ssl/certs/ca-certificates.crt && \
-    wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild_16.0+xamarinxplat.2018.09.26.17.53-0xamarin3+ubuntu1404b1_all.deb && \
-    wget https://download.mono-project.com/repo/ubuntu/pool/main/c/core-setup/msbuild-libhostfxr_2.0.0.2017.07.06.00.01-0xamarin21+ubuntu1404b1_i386.deb && \
-    wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild-sdkresolver_16.0+xamarinxplat.2018.09.26.17.53-0xamarin3+ubuntu1404b1_all.deb && \
-    wget https://download.mono-project.com/repo/ubuntu/pool/main/n/nuget/nuget_4.7.0.5148.bin-0xamarin2+ubuntu1404b1_all.deb && \
+    rm -rf /root/mono && \
+    wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild_16.3+xamarinxplat.2019.08.08.00.55-0xamarin2+ubuntu1604b1_all.deb && \
+    wget https://download.mono-project.com/repo/ubuntu/pool/main/c/core-setup/msbuild-libhostfxr_3.0.0.2019.04.16.02.13-0xamarin3+ubuntu1604b1_i386.deb && \
+    wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild-sdkresolver_16.3+xamarinxplat.2019.08.08.00.55-0xamarin2+ubuntu1604b1_all.deb && \
+    wget https://download.mono-project.com/repo/ubuntu/pool/main/n/nuget/nuget_5.2.0.6090.bin-0xamarin1+ubuntu1604b1_all.deb && \
     dpkg -i --force-all *.deb && \
     sed -i '/Depends.*mono/d' /var/lib/dpkg/status && \
     ln -s /usr/bin/mono /usr/bin/cli && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/ && \
-    rm *.deb && \
-    rm -rf /root/mono
+    rm *.deb
 
 CMD /bin/bash

--- a/Dockerfile.ubuntu-64
+++ b/Dockerfile.ubuntu-64
@@ -20,7 +20,7 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
     ln -sf /usr/bin/gcc-8 /usr/bin/gcc && \
     ln -sf /usr/bin/g++-8 /usr/bin/g++
 
-RUN git clone https://github.com/mono/mono --branch mono-${mono_version} --single-branch && \
+RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
     cd mono && git submodule update --init && \
     NOCONFIGURE=1 ./autogen.sh && \
     ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var/lib/mono --disable-boehm --host=x86_64-linux-gnu && \
@@ -28,16 +28,16 @@ RUN git clone https://github.com/mono/mono --branch mono-${mono_version} --singl
     make install && \
     cd .. && \
     cert-sync /etc/ssl/certs/ca-certificates.crt && \
-    wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild_16.0+xamarinxplat.2018.09.26.17.53-0xamarin3+ubuntu1404b1_all.deb && \
-    wget https://download.mono-project.com/repo/ubuntu/pool/main/c/core-setup/msbuild-libhostfxr_2.0.0.2017.07.06.00.01-0xamarin21+ubuntu1404b1_amd64.deb && \
-    wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild-sdkresolver_16.0+xamarinxplat.2018.09.26.17.53-0xamarin3+ubuntu1404b1_all.deb && \
-    wget https://download.mono-project.com/repo/ubuntu/pool/main/n/nuget/nuget_4.7.0.5148.bin-0xamarin2+ubuntu1404b1_all.deb && \
+    rm -rf /root/mono && \
+    wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild_16.3+xamarinxplat.2019.08.08.00.55-0xamarin2+ubuntu1604b1_all.deb && \
+    wget https://download.mono-project.com/repo/ubuntu/pool/main/c/core-setup/msbuild-libhostfxr_3.0.0.2019.04.16.02.13-0xamarin3+ubuntu1604b1_amd64.deb && \
+    wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild-sdkresolver_16.3+xamarinxplat.2019.08.08.00.55-0xamarin2+ubuntu1604b1_all.deb && \
+    wget https://download.mono-project.com/repo/ubuntu/pool/main/n/nuget/nuget_5.2.0.6090.bin-0xamarin1+ubuntu1604b1_all.deb && \
     dpkg -i --force-all *.deb && \
     sed -i '/Depends.*mono/d' /var/lib/dpkg/status && \
     ln -s /usr/bin/mono /usr/bin/cli && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/ && \
-    rm *.deb && \
-    rm -rf /root/mono
+    rm *.deb
 
 CMD /bin/bash

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -10,7 +10,7 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
                      /root/files/mingw64-binutils-2.30-5.fc29.godot.x86_64.rpm \
                      /root/files/mingw32-binutils-2.30-5.fc29.godot.x86_64.rpm
 
-RUN git clone https://github.com/mono/mono --branch mono-${mono_version} --single-branch && \
+RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
     cd mono && git submodule update --init && \
     NOCONFIGURE=1 ./autogen.sh && \
     ./configure --prefix=/root/dependencies/mono-64 --host=x86_64-w64-mingw32 --disable-boehm --disable-mcs-build --disable-executables && \

--- a/files/patches/mono-wasm-avoid-aligning-stack-bounds.patch
+++ b/files/patches/mono-wasm-avoid-aligning-stack-bounds.patch
@@ -1,0 +1,59 @@
+From aad54942583f8658ab6d7e7af5ffe3b76b3f35b3 Mon Sep 17 00:00:00 2001
+From: Zoltan Varga <vargaz@gmail.com>
+Date: Tue, 3 Sep 2019 13:27:24 -0400
+Subject: [PATCH] [wasm] Avoid aligning the stack bounds, they are not page
+ aligned on wasm.
+
+---
+ mono/utils/mono-threads-wasm.c | 8 ++++----
+ mono/utils/mono-threads.c      | 2 ++
+ 2 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/mono/utils/mono-threads-wasm.c b/mono/utils/mono-threads-wasm.c
+index 687e6c4c93e7..c61d800f4be2 100644
+--- a/mono/utils/mono-threads-wasm.c
++++ b/mono/utils/mono-threads-wasm.c
+@@ -145,10 +145,10 @@ mono_threads_platform_yield (void)
+ void
+ mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize)
+ {
++	int tmp;
+ #ifdef __EMSCRIPTEN_PTHREADS__
+ 	pthread_attr_t attr;
+ 	gint res;
+-	int tmp;
+ 
+ 	*staddr = NULL;
+ 	*stsize = (size_t)-1;
+@@ -173,13 +173,13 @@ mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize)
+ 		*staddr = (guint8*)wasm_get_stack_base ();
+ 		*stsize = wasm_get_stack_size ();
+ 	}
+-
+-	g_assert (&tmp > *staddr);
+-	g_assert (&tmp < (char*)*staddr + *stsize);
+ #else
+ 	*staddr = (guint8*)wasm_get_stack_base ();
+ 	*stsize = wasm_get_stack_size ();
+ #endif
++
++	g_assert ((guint8*)&tmp > *staddr);
++	g_assert ((guint8*)&tmp < (guint8*)*staddr + *stsize);
+ }
+ 
+ gboolean
+diff --git a/mono/utils/mono-threads.c b/mono/utils/mono-threads.c
+index 546704ff9e8f..bf73e01c7970 100644
+--- a/mono/utils/mono-threads.c
++++ b/mono/utils/mono-threads.c
+@@ -1569,8 +1569,10 @@ mono_thread_info_get_stack_bounds (guint8 **staddr, size_t *stsize)
+ 	/* Sanity check the result */
+ 	g_assert ((current > *staddr) && (current < *staddr + *stsize));
+ 
++#ifndef TARGET_WASM
+ 	/* When running under emacs, sometimes staddr is not aligned to a page size */
+ 	*staddr = (guint8*)((gssize)*staddr & ~(mono_pagesize () - 1));
++#endif
+ }
+ 
+ gboolean


### PR DESCRIPTION
To get WebAssembly templates to actually work, we need to use
Mono 6.6 (currently in preview), which doesn't have tags yet
but is in the `2019-08` branch. So I dehardcoded the `mono-`
prefix for the git tree-ish to allow using `./build.sh 2019-08`.

6.6 doesn't build with msbuild 16.0, so I'm upgrading to its
matching version 16.3. There are no DEB files for 16.3 on the
EOL'ed Ubuntu 14.04, but it seems that the 16.04 packages install
cleanly.

We also backport a patch from mono's master branch to fix wasm
support further, and enable parallel build jobs for make.