### PR TITLE
OSX: Fix config file for mono 6.0+

### DIFF
--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -38,8 +38,10 @@ RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-bra
     ln -s /usr/bin/mono /root/dependencies/mono/bin/mono && \
     ln -s /usr/bin/mono-sgen /root/dependencies/mono/bin/mono-sgen && \
     ln -sf /usr/lib/mono/* /root/dependencies/mono/lib/mono && \
-    cp -rvp /etc/mono /root/dependencies/mono/etc && \
-    cp /root/files/mono-config-macosx /root/dependencies/mono/etc/config && \
+    mkdir -p /root/dependencies/mono/etc && \
+    cp -rvp /etc/mono /root/dependencies/mono/etc/ && \
+    cp /root/dependencies/mono/etc/mono/config{,.bak} && \
+    cp /root/files/mono-config-macosx /root/dependencies/mono/etc/mono/config && \
     rm -rf /root/mono
 
 ENV MONO64_PREFIX=/root/dependencies/mono

--- a/files/mono-config-macosx
+++ b/files/mono-config-macosx
@@ -11,7 +11,9 @@
 	<dllmap dll="oci" target="libclntsh.dylib" os="!windows"/>
 	<dllmap dll="db2cli" target="libdb2_36.dylib" os="!windows"/>
 	<dllmap dll="MonoPosixHelper" target="$mono_libdir/libMonoPosixHelper.dylib" os="!windows" />
-	<dllmap dll="System.Native" target="$mono_libdir/libmono-system-native.dylib" os="!windows" />
+	<dllmap dll="System.Native" target="$mono_libdir/libmono-native.dylib" os="!windows" />
+	<dllmap dll="System.Net.Security.Native" target="$mono_libdir/libmono-native.dylib" os="!windows" />
+	<dllmap dll="System.Security.Cryptography.Native.Apple" target="$mono_libdir/libmono-native.dylib" os="osx" />
 	<dllmap dll="libmono-btls-shared" target="$mono_libdir/libmono-btls-shared.dylib" os="!windows" />
 	<dllmap dll="i:msvcrt" target="libc.dylib" os="!windows"/>
 	<dllmap dll="i:msvcrt.dll" target="libc.dylib" os="!windows"/>


### PR DESCRIPTION
This effectively means that we can't use the current Dockerfile.osx
to build mono < 6.0, as the DLL path changed.

I've asked users on Discord to confirm that this fixes the issue, will merge if they do.

Related issue (for Windows): godotengine/godot#33822.