### PR TITLE
Fixed Dockerfile::CMD syntax for Docker compatibility

### DIFF
--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -10,4 +10,4 @@ RUN dnf -y install scons java-1.8.0-openjdk-devel ncurses-compat-libs unzip whic
 ENV ANDROID_HOME=/root/
 ENV ANDROID_NDK_ROOT=/root/ndk-bundle/
 
-CMD ['/bin/bash']
+CMD ["/bin/bash"]

--- a/Dockerfile.export
+++ b/Dockerfile.export
@@ -2,4 +2,4 @@ FROM godot-fedora:latest
 
 RUN dnf -y install xorg-x11-server-Xvfb mesa-dri-drivers libXcursor libXinerama libXrandr libXi alsa-lib pulseaudio-libs java-1.8.0-openjdk-devel && dnf clean all
 
-CMD ['/bin/bash']
+CMD ["/bin/bash"]

--- a/Dockerfile.ios
+++ b/Dockerfile.ios
@@ -18,4 +18,4 @@ RUN dnf -y install automake autoconf clang gcc gcc-c++ gcc-objc gcc-objc++ cmake
 
 ENV OSXCROSS_IOS=not_nothing
 
-CMD ['/bin/bash']
+CMD ["/bin/bash"]

--- a/Dockerfile.javascript
+++ b/Dockerfile.javascript
@@ -6,4 +6,4 @@ RUN dnf -y install scons git xz java-openjdk yasm && dnf clean all && \
     /root/emsdk/emsdk install latest && \
     /root/emsdk/emsdk activate latest 
 
-CMD ['/bin/bash']
+CMD ["/bin/bash"]

--- a/Dockerfile.mono-glue
+++ b/Dockerfile.mono-glue
@@ -4,4 +4,4 @@ ARG mono_version
 
 RUN dnf -y install scons xorg-x11-server-Xvfb pkgconfig libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel libXi-devel mesa-libGL-devel alsa-lib-devel pulseaudio-libs-devel freetype-devel openssl-devel libudev-devel mesa-libGLU-devel mesa-dri-drivers && dnf clean all
 
-CMD ['/bin/bash']
+CMD ["/bin/bash"]

--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -59,4 +59,4 @@ RUN dnf -y install automake autoconf bzip2-devel clang git libicu-devel libtool 
 ENV MONO64_PREFIX=/root/dependencies/mono
 ENV OSXCROSS_ROOT=/root/osxcross
 
-CMD ['/bin/bash']
+CMD ["/bin/bash"]

--- a/Dockerfile.ubuntu-32
+++ b/Dockerfile.ubuntu-32
@@ -39,4 +39,4 @@ RUN apt-get update && \
 ENV MONO32_PREFIX=/usr
 ENV MONO64_PREFIX=/usr
 
-CMD ['/bin/bash']
+CMD ["/bin/bash"]

--- a/Dockerfile.ubuntu-64
+++ b/Dockerfile.ubuntu-64
@@ -39,4 +39,4 @@ RUN apt-get update && \
 ENV MONO32_PREFIX=/usr
 ENV MONO64_PREFIX=/usr
 
-CMD ['/bin/bash']
+CMD ["/bin/bash"]

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -37,4 +37,4 @@ RUN dnf -y install scons mingw32-gcc mingw32-gcc-c++ mingw32-winpthreads-static 
 ENV MONO32_PREFIX=/root/dependencies/mono-32
 ENV MONO64_PREFIX=/root/dependencies/mono-64
 
-CMD ['/bin/bash']
+CMD ["/bin/bash"]


### PR DESCRIPTION
Fixed issue for docker to parse CMD properly.
`/bin/sh: [/bin/bash]: No such file or directory`

From [Dockerfile  Reference ](https://docs.docker.com/engine/reference/builder/) under **CMD** section: 
> Note: The exec form is parsed as a JSON array, which means that you must use double-quotes (“) around words not single-quotes (‘).

Tested  on :
```
$ sw_vers
ProductName:	Mac OS X
ProductVersion:	10.15.1
BuildVersion:	19B88

$ docker --version
Docker version 19.03.4, build 9013bf5
```

