### PR TITLE
Mono: Allow specifying fixed git hash and pretty image version

### DIFF
--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -2,6 +2,7 @@ ARG img_version
 FROM godot-mono:${img_version}
 
 ARG mono_version
+ARG mono_commit
 
 RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
     dnf -y install --setopt=install_weak_deps=False \
@@ -18,11 +19,13 @@ ENV ANDROID_HOME=/root/sdk/
 ENV ANDROID_NDK_ROOT=/root/sdk/ndk-bundle/
 
 RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
-    cd mono && git submodule update --init && cd .. && \
+    cd /root/mono && \
+    if [ ! -z "${mono_commit}" ]; then git checkout ${mono_commit}; fi && \
+    git submodule update --init && \
     export MONO_SOURCE_ROOT=/root/mono && \
     export make="make -j" && \
-    git clone https://github.com/godotengine/godot-mono-builds && \
-    cd godot-mono-builds && \
+    git clone https://github.com/godotengine/godot-mono-builds /root/godot-mono-builds && \
+    cd /root/godot-mono-builds && \
     git checkout bd129da22b8b9c96f3e8b07af348cc5fb61504bf && \
     python3 patch_mono.py && \
     python3 android.py configure --target=all-runtime && \
@@ -30,7 +33,7 @@ RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-bra
     cd /root/mono && git clean -fdx && NOCONFIGURE=1 ./autogen.sh && \
     cd /root/godot-mono-builds && \
     python3 bcl.py make --product=android && \
-    cd .. && \
+    cd /root && \
     rm -rf /root/mono /root/godot-mono-builds
 
 CMD /bin/bash

--- a/Dockerfile.mono
+++ b/Dockerfile.mono
@@ -2,18 +2,21 @@ ARG img_version
 FROM godot-fedora:${img_version}
 
 ARG mono_version
+ARG mono_commit
 
 RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
     dnf -y install --setopt=install_weak_deps=False \
       autoconf automake cmake gcc gcc-c++ gettext libtool perl python && \
     dnf clean all && \
     git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
-    cd mono && git submodule update --init && \
+    cd /root/mono && \
+    if [ ! -z "${mono_commit}" ]; then git checkout ${mono_commit}; fi && \
+    git submodule update --init && \
     NOCONFIGURE=1 ./autogen.sh && \
     ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var/lib/mono --disable-boehm && \
     make -j && \
     make install && \
-    cd .. && \
+    cd /root && \
     cert-sync /etc/pki/tls/certs/ca-bundle.crt && \
     rpm -ivh --nodeps \
       https://download.mono-project.com/repo/centos8-stable/m/msbuild/msbuild-16.3+xamarinxplat.2019.08.08.00.55-0.xamarin.2.epel8.noarch.rpm \

--- a/Dockerfile.mono-glue
+++ b/Dockerfile.mono-glue
@@ -2,6 +2,7 @@ ARG img_version
 FROM godot-mono:${img_version}
 
 ARG mono_version
+ARG mono_commit
 
 RUN dnf -y install --setopt=install_weak_deps=False \
       xorg-x11-server-Xvfb libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel libXi-devel alsa-lib-devel pulseaudio-libs-devel libudev-devel mesa-libGL-devel mesa-libGLU-devel mesa-dri-drivers && \

--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -2,6 +2,7 @@ ARG img_version
 FROM godot-mono:${img_version}
 
 ARG mono_version
+ARG mono_commit
 
 RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
     dnf -y install --setopt=install_weak_deps=False \
@@ -17,7 +18,9 @@ ENV OSXCROSS_ROOT=/root/osxcross
 ENV PATH="/root/osxcross/target/bin:${PATH}"
 
 RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
-    cd mono && git submodule update --init && \
+    cd /root/mono && \
+    if [ ! -z "${mono_commit}" ]; then git checkout ${mono_commit}; fi && \
+    git submodule update --init && \
     export CMAKE=/root/osxcross/target/bin/x86_64-apple-darwin18-cmake && \
     NOCONFIGURE=1 ./autogen.sh && \
     ./configure --prefix=/root/dependencies/mono \
@@ -34,7 +37,7 @@ RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-bra
         CXX=o64-clang++ && \
     make -j && \
     make install && \
-    cd .. && \
+    cd /root && \
     rm -f /root/dependencies/mono/bin/mono /root/dependencies/mono/bin/mono-sgen && \
     ln -s /usr/bin/mono /root/dependencies/mono/bin/mono && \
     ln -s /usr/bin/mono-sgen /root/dependencies/mono/bin/mono-sgen && \

--- a/Dockerfile.ubuntu-32
+++ b/Dockerfile.ubuntu-32
@@ -1,6 +1,7 @@
 FROM i386/ubuntu:trusty
 
 ARG mono_version
+ARG mono_commit
 
 RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
     apt-get update && \
@@ -20,13 +21,16 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
     ln -sf /usr/bin/gcc-8 /usr/bin/gcc && \
     ln -sf /usr/bin/g++-8 /usr/bin/g++
 
-RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
-    cd mono && git submodule update --init && \
+RUN cd /root && \
+    git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
+    cd /root/mono && \
+    if [ ! -z "${mono_commit}" ]; then git checkout ${mono_commit}; fi && \
+    git submodule update --init && \
     NOCONFIGURE=1 ./autogen.sh && \
     ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var/lib/mono --disable-boehm --host=i386-linux-gnu && \
     make -j && \
     make install && \
-    cd .. && \
+    cd /root && \
     cert-sync /etc/ssl/certs/ca-certificates.crt && \
     rm -rf /root/mono && \
     wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild_16.3+xamarinxplat.2019.08.08.00.55-0xamarin2+ubuntu1604b1_all.deb && \

--- a/Dockerfile.ubuntu-64
+++ b/Dockerfile.ubuntu-64
@@ -1,6 +1,7 @@
 FROM ubuntu:trusty
 
 ARG mono_version
+ARG mono_commit
 
 RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
     apt-get update && \
@@ -20,13 +21,16 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
     ln -sf /usr/bin/gcc-8 /usr/bin/gcc && \
     ln -sf /usr/bin/g++-8 /usr/bin/g++
 
-RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
-    cd mono && git submodule update --init && \
+RUN cd /root && \
+    git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
+    cd /root/mono && \
+    if [ ! -z "${mono_commit}" ]; then git checkout ${mono_commit}; fi && \
+    git submodule update --init && \
     NOCONFIGURE=1 ./autogen.sh && \
     ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var/lib/mono --disable-boehm --host=x86_64-linux-gnu && \
     make -j && \
     make install && \
-    cd .. && \
+    cd /root && \
     cert-sync /etc/ssl/certs/ca-certificates.crt && \
     rm -rf /root/mono && \
     wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild_16.3+xamarinxplat.2019.08.08.00.55-0xamarin2+ubuntu1604b1_all.deb && \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -2,6 +2,7 @@ ARG img_version
 FROM godot-mono:${img_version}
 
 ARG mono_version
+ARG mono_commit
 
 RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
     dnf -y install --setopt=install_weak_deps=False \
@@ -9,7 +10,9 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
     dnf clean all
 
 RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
-    cd mono && git submodule update --init && \
+    cd /root/mono && \
+    if [ ! -z "${mono_commit}" ]; then git checkout ${mono_commit}; fi && \
+    git submodule update --init && \
     NOCONFIGURE=1 ./autogen.sh && \
     ./configure --prefix=/root/dependencies/mono-64 --host=x86_64-w64-mingw32 --disable-boehm --disable-mcs-build --disable-executables && \
     echo '#define HAVE_STRUCT_SOCKADDR_IN6 1' >> config.h && \
@@ -27,7 +30,7 @@ RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-bra
     echo '#define HAVE_STRUCT_SOCKADDR_IN6 1' >> config.h && \
     make -j && \
     make install && \
-    cd .. && \
+    cd /root && \
     cp /root/dependencies/mono-32/bin/libMonoPosixHelper.dll /root/dependencies/mono-32/bin/MonoPosixHelper.dll && \
     rm -f /root/dependencies/mono-32/bin/mono /root/dependencies/mono-32/bin/mono-sgen && \
     ln -s /usr/bin/mono /root/dependencies/mono-32/bin/mono && \

--- a/build.sh
+++ b/build.sh
@@ -13,9 +13,10 @@ if ! which $podman; then
 fi
 
 if [ -z "$1" ]; then
-  echo "usage: $0 <godot branch> <mono git version>"
+  echo "usage: $0 <godot branch> <mono version string> [<mono branch> <mono commit hash>]"
   echo
-  echo "For example: $0 3.1 mono-5.18.1.3"
+  echo "Examples: $0 3.1 mono-5.18.1.3"
+  echo "          $0 master mono-6.6.0.160 2019-08 bef1e6335812d32f8eab648c0228fc624b9f8357"
   echo
   exit 1
 fi
@@ -23,13 +24,31 @@ fi
 godot_branch=$1
 mono_version=$2
 img_version=$godot_branch-$mono_version
+mono_commit=
+if [ ! -z "$3" -a ! -z "$4" ]; then
+  # Optional Mono git branch and commit hash were passed,
+  # use that for the git clones.
+  mono_version=$3
+  mono_commit=$4
+fi
+echo "Building images with version: ${img_version}"
+echo "Mono version used: ${mono_version} ${mono_commit}"
+echo
+while true; do
+    read -p "Is this correct? [y/n] " yn
+    case $yn in
+        [Yy]* ) break;;
+        [Nn]* ) exit 1;;
+        * ) echo "Please answer yes or no.";;
+    esac
+done
 
 mkdir -p logs
 
 export podman_build="$podman build --build-arg img_version=${img_version}"
-export podman_build_mono="$podman_build --build-arg mono_version=${mono_version}"
+export podman_build_mono="$podman_build --build-arg mono_version=${mono_version} --build-arg mono_commit=${mono_commit}"
 
-$podman_build -t godot-fedora:${img_version} -f Dockerfile.base . 2>&1 | tee logs/base.log
+$podman build -t godot-fedora:${img_version} -f Dockerfile.base . 2>&1 | tee logs/base.log
 $podman_build -t godot-export:${img_version} -f Dockerfile.export . 2>&1 | tee logs/export.log
 
 $podman_build_mono -t godot-mono:${img_version} -f Dockerfile.mono . 2>&1 | tee logs/mono.log

--- a/build.sh
+++ b/build.sh
@@ -38,7 +38,7 @@ $podman_build_mono -v $(pwd)/files:/root/files -t godot-windows:${img_version} -
 $podman_build_mono -t godot-ubuntu-64:${img_version} -f Dockerfile.ubuntu-64 . 2>&1 | tee logs/ubuntu-64.log
 $podman_build_mono -t godot-ubuntu-32:${img_version} -f Dockerfile.ubuntu-32 . 2>&1 | tee logs/ubuntu-32.log
 $podman_build_mono -t godot-android:${img_version} -f Dockerfile.android . 2>&1 | tee logs/android.log
-$podman_build_mono -v $(pwd)/files:/root/files -t godot-javascript:${img_version}-upstream -f Dockerfile.javascript . 2>&1 | tee logs/javascript.log
+$podman_build_mono -v $(pwd)/files:/root/files -t godot-javascript:${img_version} -f Dockerfile.javascript . 2>&1 | tee logs/javascript.log
 
 $podman_build -t godot-xcode-packer:${img_version} -f Dockerfile.xcode -v $(pwd)/files:/root/files . 2>&1 | tee logs/xcode.log
 


### PR DESCRIPTION
Specifying only a branch like '2019-08' is problematic if upstream commits
something between the builds of two containers.

We could make a tarball in the first container build and reuse that, but we
need the flexibility of Git for some patching in the Android and JavaScript
builds, so instead we allow specifying a git tree-ish as the third argument.

We can therefore also give a pretty version string to use for the image name
as second argument, e.g. 6.6.0.160 for bef1e6335812d32f8eab648c0228fc624b9f8357.

As we can't `git clone` a commit hash directly, we still need to provide both
branch name and then commit hash for this use case.

Follow up to #23.