### PR TITLE
Windows: Workaround Mono 6 BCL cross-compiling bug using Wine

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -6,18 +6,15 @@ ARG mono_commit
 
 RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
     dnf -y install --setopt=install_weak_deps=False \
-      mingw32-gcc mingw32-gcc-c++ mingw32-winpthreads-static mingw64-gcc mingw64-gcc-c++ mingw64-winpthreads-static yasm && \
-    dnf clean all
-
-RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
+      mingw32-gcc mingw32-gcc-c++ mingw32-winpthreads-static mingw64-gcc mingw64-gcc-c++ mingw64-winpthreads-static yasm wine && \
+    dnf clean all && \
+    git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
     cd /root/mono && \
     if [ ! -z "${mono_commit}" ]; then git checkout ${mono_commit}; fi && \
     git submodule update --init && \
-    NOCONFIGURE=1 ./autogen.sh && \
-    ./configure --prefix=/root/dependencies/mono-64 --host=x86_64-w64-mingw32 --disable-boehm --disable-mcs-build --disable-executables && \
-    echo '#define HAVE_STRUCT_SOCKADDR_IN6 1' >> config.h && \
-    make -j && \
-    make install && \
+    git apply -3 /root/files/patches/wine-mono.patch && \
+    export WINE_BITS=64 && \
+    bash /root/files/mono-build-win32.sh --prefix=/root/dependencies/mono-64 --host=x86_64-w64-mingw32 && \
     git clean -fdx && \
     cp /root/dependencies/mono-64/bin/libMonoPosixHelper.dll /root/dependencies/mono-64/bin/MonoPosixHelper.dll && \
     rm -f /root/dependencies/mono-64/bin/mono /root/dependencies/mono-64/bin/mono-sgen && \
@@ -25,11 +22,8 @@ RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-bra
     ln -s /usr/bin/mono-sgen /root/dependencies/mono-64/bin/mono-sgen && \
     ln -sf /usr/lib/mono/* /root/dependencies/mono-64/lib/mono || /bin/true && \
     cp -rvp /etc/mono /root/dependencies/mono-64/etc && \
-    NOCONFIGURE=1 ./autogen.sh && \
-    ./configure --prefix=/root/dependencies/mono-32 --host=i686-w64-mingw32 --disable-boehm --disable-mcs-build --disable-executables && \
-    echo '#define HAVE_STRUCT_SOCKADDR_IN6 1' >> config.h && \
-    make -j && \
-    make install && \
+    export WINE_BITS=32 && \
+    bash /root/files/mono-build-win32.sh --prefix=/root/dependencies/mono-32 --host=i686-w64-mingw32 && \
     cd /root && \
     cp /root/dependencies/mono-32/bin/libMonoPosixHelper.dll /root/dependencies/mono-32/bin/MonoPosixHelper.dll && \
     rm -f /root/dependencies/mono-32/bin/mono /root/dependencies/mono-32/bin/mono-sgen && \
@@ -37,7 +31,8 @@ RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-bra
     ln -s /usr/bin/mono-sgen /root/dependencies/mono-32/bin/mono-sgen && \
     ln -sf /usr/lib/mono/* /root/dependencies/mono-32/lib/mono || /bin/true && \
     cp -rvp /etc/mono /root/dependencies/mono-32/etc && \
-    rm -rf /root/mono
+    rm -rf /root/mono && \
+    dnf -y remove wine
 
 ENV MONO32_PREFIX=/root/dependencies/mono-32
 ENV MONO64_PREFIX=/root/dependencies/mono-64

--- a/build.sh
+++ b/build.sh
@@ -53,7 +53,7 @@ $podman_build -t godot-export:${img_version} -f Dockerfile.export . 2>&1 | tee l
 
 $podman_build_mono -t godot-mono:${img_version} -f Dockerfile.mono . 2>&1 | tee logs/mono.log
 $podman_build_mono -t godot-mono-glue:${img_version} -f Dockerfile.mono-glue . 2>&1 | tee logs/mono-glue.log
-$podman_build_mono -v $(pwd)/files:/root/files -t godot-windows:${img_version} -f Dockerfile.windows . 2>&1 | tee logs/windows.log
+$podman_build_mono -v $(pwd)/files:/root/files --ulimit nofile=65536 -t godot-windows:${img_version} -f Dockerfile.windows . 2>&1 | tee logs/windows.log
 $podman_build_mono -t godot-ubuntu-64:${img_version} -f Dockerfile.ubuntu-64 . 2>&1 | tee logs/ubuntu-64.log
 $podman_build_mono -t godot-ubuntu-32:${img_version} -f Dockerfile.ubuntu-32 . 2>&1 | tee logs/ubuntu-32.log
 $podman_build_mono -t godot-android:${img_version} -f Dockerfile.android . 2>&1 | tee logs/android.log

--- a/files/mono-build-win32.sh
+++ b/files/mono-build-win32.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+echo -e '#!/bin/bash\nwine${WINE_BITS} $(dirname $0)/mono-sgen.exe "$@"' > mono/mini/mono
+chmod +x mono/mini/mono
+
+mkdir -p .bin
+echo -e '#!/bin/bash\necho $@ | awk "{print \$NF}"' > .bin/cygpath
+chmod +x .bin/cygpath
+export PATH="$(pwd)/.bin/:$PATH"
+
+./autogen.sh $@ --disable-boehm --with-mcs-docs=no HOST_PROFILE=win32
+echo '#define HAVE_STRUCT_SOCKADDR_IN6 1' >> config.h
+pushd mcs/jay
+make CC=gcc
+popd
+
+for dir in external/roslyn-binaries/Microsoft.Net.Compilers/[0-9]*; do
+  MONO_PATH="$(winepath -w $(pwd)/${dir});${MONO_PATH}"
+done
+export MONO_PATH
+
+make -j
+make install

--- a/files/patches/wine-mono.patch
+++ b/files/patches/wine-mono.patch
@@ -1,0 +1,50 @@
+commit c2e1ed54e1a3f613bdda3f085fee5b21c9fa174d
+Author: Hein-Pieter van Braam-Stewart <hp@tmm.cx>
+Date:   Sat Dec 14 23:16:19 2019 +0100
+
+    Workaround
+
+diff --git a/mcs/build/platforms/win32.make b/mcs/build/platforms/win32.make
+index 9d920a3bf9b..481227c66e3 100644
+--- a/mcs/build/platforms/win32.make
++++ b/mcs/build/platforms/win32.make
+@@ -20,10 +20,11 @@ EXTERNAL_RUNTIME = mono
+ ILDISASM = $(topdir)/../mono/mono/dis/monodis
+ 
+ PLATFORM_MAKE_CORLIB_CMP = yes
+-PLATFORM_CHANGE_SEPARATOR_CMD=tr '/' '\\\\'
++#PLATFORM_CHANGE_SEPARATOR_CMD=tr '\\' '/'
++PLATFORM_CHANGE_SEPARATOR_CMD=cat
+ PLATFORM_PATH_SEPARATOR = ;
+ 
+-override CURDIR:=$(shell cygpath -m $(CURDIR))
++#override CURDIR:=$(shell cygpath -m $(CURDIR))
+ 
+ hidden_prefix = 
+ hidden_suffix = .tmp
+diff --git a/mcs/build/profiles/build.make b/mcs/build/profiles/build.make
+index b1c9a410e1e..004f9f33280 100644
+--- a/mcs/build/profiles/build.make
++++ b/mcs/build/profiles/build.make
+@@ -32,7 +32,7 @@ endif
+ #
+ ILASM = $(PROFILE_RUNTIME) $(RUNTIME_FLAGS) $(topdir)/class/lib/$(BUILD_TOOLS_PROFILE)/tmp/ilasm.exe
+ STRING_REPLACER = $(PROFILE_RUNTIME) $(RUNTIME_FLAGS) $(topdir)/class/lib/$(BUILD_TOOLS_PROFILE)/tmp/cil-stringreplacer.exe
+-GENSOURCES =$(PROFILE_RUNTIME) $(RUNTIME_FLAGS) $(topdir)/class/lib/$(BUILD_TOOLS_PROFILE)/tmp/gensources.exe
++GENSOURCES = mono $(topdir)/class/lib/$(BUILD_TOOLS_PROFILE)/tmp/gensources.exe
+ 
+ MCS = $(BOOTSTRAP_MCS)
+ 
+diff --git a/mcs/build/rules.make b/mcs/build/rules.make
+index a77f1d11cc6..7a0bbfc0924 100644
+--- a/mcs/build/rules.make
++++ b/mcs/build/rules.make
+@@ -63,7 +63,7 @@ INTERNAL_CSC = CSC_SDK_PATH_DISABLED= $(RUNTIME) $(RUNTIME_FLAGS) $(CSC_RUNTIME_
+ RESGEN = MONO_PATH="$(topdir)/class/lib/$(BUILD_TOOLS_PROFILE)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" $(RUNTIME) $(RUNTIME_FLAGS) $(topdir)/class/lib/$(BUILD_TOOLS_PROFILE)/resgen.exe
+ STRING_REPLACER = MONO_PATH="$(topdir)/class/lib/$(BUILD_TOOLS_PROFILE)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" $(RUNTIME) $(RUNTIME_FLAGS) $(topdir)/class/lib/$(BUILD_TOOLS_PROFILE)/cil-stringreplacer.exe
+ ILASM = MONO_PATH="$(topdir)/class/lib/$(BUILD_TOOLS_PROFILE)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" $(RUNTIME) $(RUNTIME_FLAGS) $(topdir)/class/lib/$(BUILD_TOOLS_PROFILE)/ilasm.exe
+-GENSOURCES = MONO_PATH="$(topdir)/class/lib/$(BUILD_TOOLS_PROFILE)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" $(RUNTIME) $(RUNTIME_FLAGS) $(topdir)/class/lib/$(BUILD_TOOLS_PROFILE)/gensources.exe
++GENSOURCES = MONO_PATH="$(topdir)/class/lib/$(BUILD_TOOLS_PROFILE)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" mono $(topdir)/class/lib/$(BUILD_TOOLS_PROFILE)/gensources.exe
+ 
+ depsdir = $(topdir)/build/deps
+ 


### PR DESCRIPTION
This can be reverted once a proper fix has been deployed in upstream
Mono. No ETA yet as we're busy and it's unlikely to happen if we don't
do it ourselves :)

Co-authored-by: @hpvb

---

I made it all one `RUN` step and removed `wine` in the end, so we should hopefully end up with a leaner container. It's just temporary until @hpvb has time to work on using proper build steps to improve the overall workflow.