### PR TITLE
Windows: Prevent 32-bit build failure from skipping symlinks

### DIFF
--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -26,7 +26,7 @@ RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-bra
     export make="make -j" && \
     git clone https://github.com/godotengine/godot-mono-builds /root/godot-mono-builds && \
     cd /root/godot-mono-builds && \
-    git checkout bd129da22b8b9c96f3e8b07af348cc5fb61504bf && \
+    git checkout 710b275fbf29ddb03fd5285c51782951a110cdab && \
     python3 patch_mono.py && \
     python3 android.py configure --target=all-runtime && \
     python3 android.py make --target=all-runtime && \

--- a/Dockerfile.javascript
+++ b/Dockerfile.javascript
@@ -23,7 +23,7 @@ RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-bra
     export make="make -j" && \
     git clone https://github.com/godotengine/godot-mono-builds /root/godot-mono-builds && \
     cd /root/godot-mono-builds && \
-    git checkout bd129da22b8b9c96f3e8b07af348cc5fb61504bf && \
+    git checkout 710b275fbf29ddb03fd5285c51782951a110cdab && \
     python3 patch_emscripten.py && \
     python3 wasm.py configure --target=runtime && \
     python3 wasm.py make --target=runtime && \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -20,16 +20,16 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
     rm -f /root/dependencies/mono-64/bin/mono /root/dependencies/mono-64/bin/mono-sgen && \
     ln -s /usr/bin/mono /root/dependencies/mono-64/bin/mono && \
     ln -s /usr/bin/mono-sgen /root/dependencies/mono-64/bin/mono-sgen && \
-    ln -sf /usr/lib/mono/* /root/dependencies/mono-64/lib/mono || /bin/true && \
+    (ln -sf /usr/lib/mono/* /root/dependencies/mono-64/lib/mono/ || /bin/true) && \
     cp -rvp /etc/mono /root/dependencies/mono-64/etc && \
     export WINE_BITS=32 && \
-    bash /root/files/mono-build-win32.sh --prefix=/root/dependencies/mono-32 --host=i686-w64-mingw32 && \
+    (bash /root/files/mono-build-win32.sh --prefix=/root/dependencies/mono-32 --host=i686-w64-mingw32 || /bin/true) && \
     cd /root && \
     cp /root/dependencies/mono-32/bin/libMonoPosixHelper.dll /root/dependencies/mono-32/bin/MonoPosixHelper.dll && \
     rm -f /root/dependencies/mono-32/bin/mono /root/dependencies/mono-32/bin/mono-sgen && \
     ln -s /usr/bin/mono /root/dependencies/mono-32/bin/mono && \
     ln -s /usr/bin/mono-sgen /root/dependencies/mono-32/bin/mono-sgen && \
-    ln -sf /usr/lib/mono/* /root/dependencies/mono-32/lib/mono || /bin/true && \
+    (ln -sf /usr/lib/mono/* /root/dependencies/mono-32/lib/mono/ || /bin/true) && \
     cp -rvp /etc/mono /root/dependencies/mono-32/etc && \
     rm -rf /root/mono && \
     dnf -y remove wine


### PR DESCRIPTION
Like most programming language, in a logic statement `A && B || C`,
bash will not evaluate B if A is false (failing in our case).
Using `A && (B || C)` to prevent that.

A build error in the Windows 32-bit Mono build thus caused skipping
all subsequent `ln` statements up until `|| /bin/true`, which is used
to link only the folders which are missing from the self-built mono
prefix.

The build error still needs to be fixed but it doesn't seem to prevent
using the resulting container to build 32-bit Windows binaries.

---

The other commit is a updating the Android and JS containers to the latest commit on https://github.com/godotengine/godot-mono-builds, which reduces the size of their BCL somewhat and should make templates leaner.