### PR TITLE
Windows: Set WINEPATH for 32-bit wine to fix Mono build

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -20,16 +20,14 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
     rm -f /root/dependencies/mono-64/bin/mono /root/dependencies/mono-64/bin/mono-sgen && \
     ln -s /usr/bin/mono /root/dependencies/mono-64/bin/mono && \
     ln -s /usr/bin/mono-sgen /root/dependencies/mono-64/bin/mono-sgen && \
-    (ln -sf /usr/lib/mono/* /root/dependencies/mono-64/lib/mono/ || /bin/true) && \
     cp -rvp /etc/mono /root/dependencies/mono-64/etc && \
     export WINE_BITS=32 && \
-    (bash /root/files/mono-build-win32.sh --prefix=/root/dependencies/mono-32 --host=i686-w64-mingw32 || /bin/true) && \
+    bash /root/files/mono-build-win32.sh --prefix=/root/dependencies/mono-32 --host=i686-w64-mingw32 && \
     cd /root && \
     cp /root/dependencies/mono-32/bin/libMonoPosixHelper.dll /root/dependencies/mono-32/bin/MonoPosixHelper.dll && \
     rm -f /root/dependencies/mono-32/bin/mono /root/dependencies/mono-32/bin/mono-sgen && \
     ln -s /usr/bin/mono /root/dependencies/mono-32/bin/mono && \
     ln -s /usr/bin/mono-sgen /root/dependencies/mono-32/bin/mono-sgen && \
-    (ln -sf /usr/lib/mono/* /root/dependencies/mono-32/lib/mono/ || /bin/true) && \
     cp -rvp /etc/mono /root/dependencies/mono-32/etc && \
     rm -rf /root/mono && \
     dnf -y remove wine

--- a/files/mono-build-win32.sh
+++ b/files/mono-build-win32.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-echo -e '#!/bin/bash\nwine${WINE_BITS} $(dirname $0)/mono-sgen.exe "$@"' > mono/mini/mono
+if [ "${WINE_BITS}" == "64" ]; then
+  export WINEPATH="/usr/x86_64-w64-mingw32/sys-root/mingw/bin/"
+else
+  export WINEPATH="/usr/i686-w64-mingw32/sys-root/mingw/bin/"
+fi
+
+echo -e '#!/bin/bash\n'"wine${WINE_BITS}"' $(dirname $0)/mono-sgen.exe "$@"' > mono/mini/mono
 chmod +x mono/mini/mono
 
 mkdir -p .bin


### PR DESCRIPTION
Symlinking the BCL from `/usr/lib/mono` no longer seems needed
for either architecture, everything is built properly.

Fixes #34.

----

This seemed to work in-container when doing a test. I'm now making a full rebuild of the container and will do a test Mono win64 and win32 build off the `master` branch to confirm that everything works as intended.