### PR TITLE
Mono: Add patch from Unity fork to fix TLS re-attachment

### DIFF
--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -22,6 +22,7 @@ RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-bra
     cd /root/mono && \
     if [ ! -z "${mono_commit}" ]; then git checkout ${mono_commit}; fi && \
     git submodule update --init && \
+    git apply -3 /root/files/patches/mono-unity-Clear-TLS-instead-of-aborting.patch && \
     export MONO_SOURCE_ROOT=/root/mono && \
     export make="make -j" && \
     git clone https://github.com/godotengine/godot-mono-builds /root/godot-mono-builds && \

--- a/Dockerfile.javascript
+++ b/Dockerfile.javascript
@@ -18,6 +18,7 @@ RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-bra
     cd /root/mono && \
     if [ ! -z "${mono_commit}" ]; then git checkout ${mono_commit}; fi && \
     git submodule update --init && \
+    git apply -3 /root/files/patches/mono-unity-Clear-TLS-instead-of-aborting.patch && \
     git apply -3 /root/files/patches/mono-pr16636-wasm-bugfix-and-update.diff && \
     export MONO_SOURCE_ROOT=/root/mono && \
     export make="make -j" && \

--- a/Dockerfile.mono
+++ b/Dockerfile.mono
@@ -12,6 +12,7 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
     cd /root/mono && \
     if [ ! -z "${mono_commit}" ]; then git checkout ${mono_commit}; fi && \
     git submodule update --init && \
+    git apply -3 /root/files/patches/mono-unity-Clear-TLS-instead-of-aborting.patch && \
     NOCONFIGURE=1 ./autogen.sh && \
     ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var/lib/mono --disable-boehm && \
     make -j && \

--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -21,6 +21,7 @@ RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-bra
     cd /root/mono && \
     if [ ! -z "${mono_commit}" ]; then git checkout ${mono_commit}; fi && \
     git submodule update --init && \
+    git apply -3 /root/files/patches/mono-unity-Clear-TLS-instead-of-aborting.patch && \
     export CMAKE=/root/osxcross/target/bin/x86_64-apple-darwin18-cmake && \
     NOCONFIGURE=1 ./autogen.sh && \
     ./configure --prefix=/root/dependencies/mono \

--- a/Dockerfile.ubuntu-32
+++ b/Dockerfile.ubuntu-32
@@ -26,6 +26,7 @@ RUN cd /root && \
     cd /root/mono && \
     if [ ! -z "${mono_commit}" ]; then git checkout ${mono_commit}; fi && \
     git submodule update --init && \
+    git apply -3 /root/files/patches/mono-unity-Clear-TLS-instead-of-aborting.patch && \
     NOCONFIGURE=1 ./autogen.sh && \
     ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var/lib/mono --disable-boehm --host=i386-linux-gnu && \
     make -j && \

--- a/Dockerfile.ubuntu-64
+++ b/Dockerfile.ubuntu-64
@@ -26,6 +26,7 @@ RUN cd /root && \
     cd /root/mono && \
     if [ ! -z "${mono_commit}" ]; then git checkout ${mono_commit}; fi && \
     git submodule update --init && \
+    git apply -3 /root/files/patches/mono-unity-Clear-TLS-instead-of-aborting.patch && \
     NOCONFIGURE=1 ./autogen.sh && \
     ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var/lib/mono --disable-boehm --host=x86_64-linux-gnu && \
     make -j && \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -12,6 +12,7 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
     cd /root/mono && \
     if [ ! -z "${mono_commit}" ]; then git checkout ${mono_commit}; fi && \
     git submodule update --init && \
+    git apply -3 /root/files/patches/mono-unity-Clear-TLS-instead-of-aborting.patch && \
     git apply -3 /root/files/patches/wine-mono.patch && \
     export WINE_BITS=64 && \
     bash /root/files/mono-build-win32.sh --prefix=/root/dependencies/mono-64 --host=x86_64-w64-mingw32 && \

--- a/build.sh
+++ b/build.sh
@@ -46,18 +46,18 @@ done
 mkdir -p logs
 
 export podman_build="$podman build --build-arg img_version=${img_version}"
-export podman_build_mono="$podman_build --build-arg mono_version=${mono_version} --build-arg mono_commit=${mono_commit}"
+export podman_build_mono="$podman_build --build-arg mono_version=${mono_version} --build-arg mono_commit=${mono_commit} -v $(pwd)/files:/root/files"
 
 $podman build -t godot-fedora:${img_version} -f Dockerfile.base . 2>&1 | tee logs/base.log
 $podman_build -t godot-export:${img_version} -f Dockerfile.export . 2>&1 | tee logs/export.log
 
 $podman_build_mono -t godot-mono:${img_version} -f Dockerfile.mono . 2>&1 | tee logs/mono.log
 $podman_build_mono -t godot-mono-glue:${img_version} -f Dockerfile.mono-glue . 2>&1 | tee logs/mono-glue.log
-$podman_build_mono -v $(pwd)/files:/root/files --ulimit nofile=65536 -t godot-windows:${img_version} -f Dockerfile.windows . 2>&1 | tee logs/windows.log
+$podman_build_mono -t godot-windows:${img_version} -f Dockerfile.windows --ulimit nofile=65536 . 2>&1 | tee logs/windows.log
 $podman_build_mono -t godot-ubuntu-64:${img_version} -f Dockerfile.ubuntu-64 . 2>&1 | tee logs/ubuntu-64.log
 $podman_build_mono -t godot-ubuntu-32:${img_version} -f Dockerfile.ubuntu-32 . 2>&1 | tee logs/ubuntu-32.log
 $podman_build_mono -t godot-android:${img_version} -f Dockerfile.android . 2>&1 | tee logs/android.log
-$podman_build_mono -v $(pwd)/files:/root/files -t godot-javascript:${img_version} -f Dockerfile.javascript . 2>&1 | tee logs/javascript.log
+$podman_build_mono -t godot-javascript:${img_version} -f Dockerfile.javascript . 2>&1 | tee logs/javascript.log
 
 $podman_build -t godot-xcode-packer:${img_version} -f Dockerfile.xcode -v $(pwd)/files:/root/files . 2>&1 | tee logs/xcode.log
 
@@ -72,7 +72,7 @@ if [ ! -e files/MacOSX10.14.sdk.tar.xz ] || [ ! -e files/iPhoneOS12.4.sdk.tar.xz
 fi
 
 $podman_build -t godot-ios:${img_version} -f Dockerfile.ios -v $(pwd)/files:/root/files . 2>&1 | tee logs/ios.log
-$podman_build_mono -t godot-osx:${img_version} -f Dockerfile.osx -v $(pwd)/files:/root/files . 2>&1 | tee logs/osx.log
+$podman_build_mono -t godot-osx:${img_version} -f Dockerfile.osx . 2>&1 | tee logs/osx.log
 
 if [ ! -e files/msvc2017.tar ]; then
   echo

--- a/files/patches/mono-unity-Clear-TLS-instead-of-aborting.patch
+++ b/files/patches/mono-unity-Clear-TLS-instead-of-aborting.patch
@@ -1,0 +1,38 @@
+Rediffed against 6.6.0.161 with condition improved based on feedback
+from Ignacio Etcheverry.
+
+From 995768f7dc3af7b3d19fcedd1244087a4a89bc5c Mon Sep 17 00:00:00 2001
+From: Josh Peterson <petersonjm1@gmail.com>
+Date: Tue, 30 Aug 2016 14:47:30 -0400
+Subject: [PATCH] Clear TLS instead of aborting
+
+Often in Unity native code will attach to a managed thread, detach, then
+attach again. This occurs most regularly in the audio code. Whent this
+happens the debugger thread local storage will already be allocated for
+the thread. This is acceptable, so instead of asserting, we clear the
+previous thread local storage and create a new one.
+
+This was originally changed in the Unity fork at: https://github.com/Unity-Technologies/mono/commit/70736c0c548af244d2a16c39790f32711fefee5b
+---
+ mono/mini/debugger-agent.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/mono/mini/debugger-agent.c b/mono/mini/debugger-agent.c
+index df6329391df..05f30d5b4dc 100644
+--- a/mono/mini/debugger-agent.c
++++ b/mono/mini/debugger-agent.c
+@@ -4088,8 +4088,12 @@ thread_startup (MonoProfiler *prof, uintptr_t tid)
+ 	}
+ 
+ 	tls = (DebuggerTlsData *)mono_native_tls_get_value (debugger_tls_id);
+-	g_assert (!tls);
+-	// FIXME: Free this somewhere
++	if (tls) {
++		if (!tls->terminated) {
++			MONO_GC_UNREGISTER_ROOT(tls->thread);
++		}
++		g_free (tls);
++	}
+ 	tls = g_new0 (DebuggerTlsData, 1);
+ 	MONO_GC_REGISTER_ROOT_SINGLE (tls->thread, MONO_ROOT_SOURCE_DEBUGGER, NULL, "Debugger Thread Reference");
+ 	tls->thread = thread;


### PR DESCRIPTION
Fixes godotengine/godot#33735.

---

I already rebuilt all containers successfully with this patch.

I'll make a test build for desktop platforms to confirm that it fixes the issue.