### PR TITLE
Fix windows docker, reduce redundancy, hadolint recommendations

### DIFF
--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -1,9 +1,9 @@
 ARG img_version
 FROM godot-mono:${img_version}
-
 ARG mono_version
 
-RUN if [ -z "${mono_version}" ]; then echo -e "\n\nArgument mono_version is mandatory!\n\n"; exit 1; fi && \
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN if [ -z "${mono_version}" ]; then printf "\n\nArgument mono_version is mandatory!\n\n"; exit 1; fi && \
     dnf -y install --setopt=install_weak_deps=False \
       gcc gcc-c++ java-1.8.0-openjdk-devel ncurses-compat-libs && \
     dnf clean packages && \
@@ -32,4 +32,4 @@ RUN cp -a /root/files/${mono_version} /root && \
     cd /root && \
     rm -rf /root/${mono_version} /root/godot-mono-builds
 
-CMD /bin/bash
+CMD ["/bin/bash"]

--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -2,12 +2,11 @@ ARG img_version
 FROM godot-mono:${img_version}
 
 ARG mono_version
-ARG mono_commit
 
-RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
+RUN if [ -z "${mono_version}" ]; then echo -e "\n\nArgument mono_version is mandatory!\n\n"; exit 1; fi && \
     dnf -y install --setopt=install_weak_deps=False \
       gcc gcc-c++ java-1.8.0-openjdk-devel ncurses-compat-libs && \
-    dnf clean all && \
+    dnf clean packages && \
     mkdir sdk && cd sdk && \
     curl -LO https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip && \
     unzip sdk-tools-linux-4333796.zip && \
@@ -18,12 +17,8 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
 ENV ANDROID_HOME=/root/sdk/
 ENV ANDROID_NDK_ROOT=/root/sdk/ndk-bundle/
 
-RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
-    cd /root/mono && \
-    if [ ! -z "${mono_commit}" ]; then git checkout ${mono_commit}; fi && \
-    git submodule update --init && \
-    git apply -3 /root/files/patches/mono-unity-Clear-TLS-instead-of-aborting.patch && \
-    export MONO_SOURCE_ROOT=/root/mono && \
+RUN cp -a /root/files/${mono_version} /root && \
+    export MONO_SOURCE_ROOT=/root/${mono_version} && \
     export make="make -j" && \
     git clone https://github.com/godotengine/godot-mono-builds /root/godot-mono-builds && \
     cd /root/godot-mono-builds && \
@@ -31,10 +26,10 @@ RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-bra
     python3 patch_mono.py && \
     python3 android.py configure --target=all-runtime && \
     python3 android.py make --target=all-runtime && \
-    cd /root/mono && git clean -fdx && NOCONFIGURE=1 ./autogen.sh && \
+    cd /root/${mono_version} && git clean -fdx && NOCONFIGURE=1 ./autogen.sh && \
     cd /root/godot-mono-builds && \
     python3 bcl.py make --product=android && \
     cd /root && \
-    rm -rf /root/mono /root/godot-mono-builds
+    rm -rf /root/${mono_version} /root/godot-mono-builds
 
 CMD /bin/bash

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -7,4 +7,4 @@ RUN dnf -y upgrade --setopt=install_weak_deps=False && \
       bash bzip2 curl git make patch pkgconfig python3 scons unzip which xz && \
     dnf clean packages
 
-CMD /bin/true
+CMD ["/bin/bash"]

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -5,6 +5,6 @@ WORKDIR /root
 RUN dnf -y upgrade --setopt=install_weak_deps=False && \
     dnf -y install --setopt=install_weak_deps=False \
       bash bzip2 curl git make patch pkgconfig python3 scons unzip which xz && \
-    dnf clean all
+    dnf clean packages
 
 CMD /bin/true

--- a/Dockerfile.export
+++ b/Dockerfile.export
@@ -3,6 +3,6 @@ FROM godot-fedora:${img_version}
 
 RUN dnf -y install --setopt=install_weak_deps=False \
       xorg-x11-server-Xvfb mesa-dri-drivers libXcursor libXinerama libXrandr libXi alsa-lib pulseaudio-libs java-1.8.0-openjdk-devel && \
-    dnf clean all
+    dnf clean packages
 
 CMD /bin/bash

--- a/Dockerfile.export
+++ b/Dockerfile.export
@@ -5,4 +5,4 @@ RUN dnf -y install --setopt=install_weak_deps=False \
       xorg-x11-server-Xvfb mesa-dri-drivers libXcursor libXinerama libXrandr libXi alsa-lib pulseaudio-libs java-1.8.0-openjdk-devel && \
     dnf clean packages
 
-CMD /bin/bash
+CMD ["/bin/bash"]

--- a/Dockerfile.ios
+++ b/Dockerfile.ios
@@ -3,8 +3,8 @@ FROM godot-fedora:${img_version}
 
 RUN dnf -y install --setopt=install_weak_deps=False \
       automake autoconf clang gcc gcc-c++ gcc-objc gcc-objc++ cmake libicu-devel libtool libxml2-devel llvm-devel openssl-devel perl python yasm && \
-    dnf clean all && \
-    git clone https://github.com/tpoechtrager/cctools-port.git && \
+    dnf clean packages && \
+    git clone https://github.com/tpoechtrager/cctools-port.git --progress && \
     cd /root/cctools-port && \
     git checkout 8239a5211bcf07d6b9d359782e1a889ec1d7cce5 && \
     sed -i 's#./autogen.sh#libtoolize -c -i --force\n./autogen.sh#' usage_examples/ios_toolchain/build.sh && \

--- a/Dockerfile.ios
+++ b/Dockerfile.ios
@@ -22,4 +22,4 @@ RUN dnf -y install --setopt=install_weak_deps=False \
 
 ENV OSXCROSS_IOS=not_nothing
 
-CMD /bin/bash
+CMD ["/bin/bash"]

--- a/Dockerfile.javascript
+++ b/Dockerfile.javascript
@@ -2,36 +2,32 @@ ARG img_version
 FROM godot-mono:${img_version}
 
 ARG mono_version
-ARG mono_commit
 
 RUN dnf -y install --setopt=install_weak_deps=False \
       java-openjdk yasm && \
-    dnf clean all && \
-    git clone https://github.com/emscripten-core/emsdk && \
+    dnf clean packages && \
+    git clone https://github.com/emscripten-core/emsdk --progress && \
     cd emsdk && \
     git checkout a5082b232617c762cb65832429f896c838df2483 && \
     ./emsdk install 1.38.47-upstream && \
     ./emsdk activate 1.38.47-upstream && \
     echo "source /root/emsdk/emsdk_env.sh" >> /root/.bashrc
 
-RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
-    cd /root/mono && \
-    if [ ! -z "${mono_commit}" ]; then git checkout ${mono_commit}; fi && \
-    git submodule update --init && \
-    git apply -3 /root/files/patches/mono-unity-Clear-TLS-instead-of-aborting.patch && \
-    git apply -3 /root/files/patches/mono-pr16636-wasm-bugfix-and-update.diff && \
-    export MONO_SOURCE_ROOT=/root/mono && \
+RUN cp -a /root/files/${mono_version} /root && \
+    cd /root/${mono_version} && \
+    patch -p1 < /root/files/patches/mono-pr16636-wasm-bugfix-and-update.diff && \
+    export MONO_SOURCE_ROOT=/root/${mono_version} && \
     export make="make -j" && \
-    git clone https://github.com/godotengine/godot-mono-builds /root/godot-mono-builds && \
+    git clone https://github.com/godotengine/godot-mono-builds /root/godot-mono-builds --progress && \
     cd /root/godot-mono-builds && \
     git checkout 710b275fbf29ddb03fd5285c51782951a110cdab && \
     python3 patch_emscripten.py && \
     python3 wasm.py configure --target=runtime && \
     python3 wasm.py make --target=runtime && \
-    cd /root/mono && git clean -fdx && NOCONFIGURE=1 ./autogen.sh && \
+    cd /root/${mono_version} && git clean -fdx && NOCONFIGURE=1 ./autogen.sh && \
     cd /root/godot-mono-builds && \
     python3 bcl.py make --product wasm && \
     cd /root && \
-    rm -rf /root/mono /root/godot-mono-builds
+    rm -rf /root/${mono_version} /root/godot-mono-builds
 
 CMD /bin/bash

--- a/Dockerfile.javascript
+++ b/Dockerfile.javascript
@@ -3,7 +3,8 @@ FROM godot-mono:${img_version}
 
 ARG mono_version
 
-RUN dnf -y install --setopt=install_weak_deps=False \
+RUN if [ -z "${mono_version}" ]; then printf "\n\nArgument mono_version is mandatory!\n\n"; exit 1; fi && \
+    dnf -y install --setopt=install_weak_deps=False \
       java-openjdk yasm && \
     dnf clean packages && \
     git clone https://github.com/emscripten-core/emsdk --progress && \
@@ -30,4 +31,4 @@ RUN cp -a /root/files/${mono_version} /root && \
     cd /root && \
     rm -rf /root/${mono_version} /root/godot-mono-builds
 
-CMD /bin/bash
+CMD ["/bin/bash"]

--- a/Dockerfile.mono
+++ b/Dockerfile.mono
@@ -2,28 +2,24 @@ ARG img_version
 FROM godot-fedora:${img_version}
 
 ARG mono_version
-ARG mono_commit
 
-RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
+RUN if [ -z "${mono_version}" ]; then echo -e "\n\nArgument mono_version is mandatory!\n\n"; exit 1; fi && \
     dnf -y install --setopt=install_weak_deps=False \
       autoconf automake cmake gcc gcc-c++ gettext libtool perl python && \
-    dnf clean all && \
-    git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
-    cd /root/mono && \
-    if [ ! -z "${mono_commit}" ]; then git checkout ${mono_commit}; fi && \
-    git submodule update --init && \
-    git apply -3 /root/files/patches/mono-unity-Clear-TLS-instead-of-aborting.patch && \
+    dnf clean packages && \
+    cp -a /root/files/${mono_version} /root && \
+    cd /root/${mono_version} && \
     NOCONFIGURE=1 ./autogen.sh && \
     ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var/lib/mono --disable-boehm && \
     make -j && \
     make install && \
     cd /root && \
+    rm -rf /root/${mono_version} && \
     cert-sync /etc/pki/tls/certs/ca-bundle.crt && \
     rpm -ivh --nodeps \
       https://download.mono-project.com/repo/centos8-stable/m/msbuild/msbuild-16.3+xamarinxplat.2019.08.08.00.55-0.xamarin.2.epel8.noarch.rpm \
       https://download.mono-project.com/repo/centos8-stable/m/msbuild-libhostfxr/msbuild-libhostfxr-3.0.0.2019.04.16.02.13-0.xamarin.4.epel8.x86_64.rpm \
       https://download.mono-project.com/repo/centos8-stable/m/msbuild/msbuild-sdkresolver-16.3+xamarinxplat.2019.08.08.00.55-0.xamarin.2.epel8.noarch.rpm \
-      https://download.mono-project.com/repo/centos8-stable/n/nuget/nuget-5.2.0.6090.bin-0.xamarin.1.epel8.noarch.rpm && \
-    rm -rf /root/mono
+      https://download.mono-project.com/repo/centos8-stable/n/nuget/nuget-5.2.0.6090.bin-0.xamarin.1.epel8.noarch.rpm
 
 CMD /bin/bash

--- a/Dockerfile.mono
+++ b/Dockerfile.mono
@@ -3,7 +3,7 @@ FROM godot-fedora:${img_version}
 
 ARG mono_version
 
-RUN if [ -z "${mono_version}" ]; then echo -e "\n\nArgument mono_version is mandatory!\n\n"; exit 1; fi && \
+RUN if [ -z "${mono_version}" ]; then printf "\n\nArgument mono_version is mandatory!\n\n"; exit 1; fi && \
     dnf -y install --setopt=install_weak_deps=False \
       autoconf automake cmake gcc gcc-c++ gettext libtool perl python && \
     dnf clean packages && \
@@ -22,4 +22,4 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nArgument mono_version is mand
       https://download.mono-project.com/repo/centos8-stable/m/msbuild/msbuild-sdkresolver-16.3+xamarinxplat.2019.08.08.00.55-0.xamarin.2.epel8.noarch.rpm \
       https://download.mono-project.com/repo/centos8-stable/n/nuget/nuget-5.2.0.6090.bin-0.xamarin.1.epel8.noarch.rpm
 
-CMD /bin/bash
+CMD ["/bin/bash"]

--- a/Dockerfile.mono-glue
+++ b/Dockerfile.mono-glue
@@ -7,4 +7,4 @@ RUN dnf -y install --setopt=install_weak_deps=False \
       xorg-x11-server-Xvfb libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel libXi-devel alsa-lib-devel pulseaudio-libs-devel libudev-devel mesa-libGL-devel mesa-libGLU-devel mesa-dri-drivers && \
     dnf clean packages
 
-CMD /bin/bash
+CMD ["/bin/bash"]

--- a/Dockerfile.mono-glue
+++ b/Dockerfile.mono-glue
@@ -2,10 +2,9 @@ ARG img_version
 FROM godot-mono:${img_version}
 
 ARG mono_version
-ARG mono_commit
 
 RUN dnf -y install --setopt=install_weak_deps=False \
       xorg-x11-server-Xvfb libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel libXi-devel alsa-lib-devel pulseaudio-libs-devel libudev-devel mesa-libGL-devel mesa-libGLU-devel mesa-dri-drivers && \
-    dnf clean all
+    dnf clean packages
 
 CMD /bin/bash

--- a/Dockerfile.msvc
+++ b/Dockerfile.msvc
@@ -27,4 +27,4 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     rm -rf /root/.wine/drive_c/users/root/Temp/* && \
     rm -rf /root/.cache
     
-CMD /bin/bash
+CMD ["/bin/bash"]

--- a/Dockerfile.msvc
+++ b/Dockerfile.msvc
@@ -5,7 +5,7 @@ ENV WINEDEBUG=-all
 
 RUN dnf -y install --setopt=install_weak_deps=False \
       wine winetricks xorg-x11-server-Xvfb p7zip-plugins findutils && \
-    dnf clean all && \
+    dnf clean packages && \
     curl -LO https://github.com/GodotBuilder/godot-builds/releases/download/_tools/angle.7z && \
     curl -LO https://www.python.org/ftp/python/3.7.2/python-3.7.2-amd64.exe && \
     xvfb-run sh -c "winetricks -q vcrun2017; wineserver -w" ;\

--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -3,7 +3,7 @@ FROM godot-mono:${img_version}
 
 ARG mono_version
 
-RUN if [ -z "${mono_version}" ]; then echo -e "\n\nArgument mono_version is mandatory!\n\n"; exit 1; fi && \
+RUN if [ -z "${mono_version}" ]; then printf "\n\nArgument mono_version is mandatory!\n\n"; exit 1; fi && \
     dnf -y install --setopt=install_weak_deps=False \
       automake autoconf bzip2-devel clang libicu-devel libtool libxml2-devel llvm-devel openssl-devel yasm && \
     dnf clean packages && \
@@ -46,4 +46,4 @@ RUN cp -a /root/files/${mono_version} /root && \
 
 ENV MONO64_PREFIX=/root/dependencies/mono
 
-CMD /bin/bash
+CMD ["/bin/bash"]

--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -2,13 +2,12 @@ ARG img_version
 FROM godot-mono:${img_version}
 
 ARG mono_version
-ARG mono_commit
 
-RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
+RUN if [ -z "${mono_version}" ]; then echo -e "\n\nArgument mono_version is mandatory!\n\n"; exit 1; fi && \
     dnf -y install --setopt=install_weak_deps=False \
       automake autoconf bzip2-devel clang libicu-devel libtool libxml2-devel llvm-devel openssl-devel yasm && \
-    dnf clean all && \
-    git clone https://github.com/tpoechtrager/osxcross.git && \
+    dnf clean packages && \
+    git clone https://github.com/tpoechtrager/osxcross.git --progress && \
     cd /root/osxcross && \
     git checkout 542acc2ef6c21aeb3f109c03748b1015a71fed63 && \
     ln -s /root/files/MacOSX10.14.sdk.tar.xz /root/osxcross/tarballs && \
@@ -17,11 +16,8 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
 ENV OSXCROSS_ROOT=/root/osxcross
 ENV PATH="/root/osxcross/target/bin:${PATH}"
 
-RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
-    cd /root/mono && \
-    if [ ! -z "${mono_commit}" ]; then git checkout ${mono_commit}; fi && \
-    git submodule update --init && \
-    git apply -3 /root/files/patches/mono-unity-Clear-TLS-instead-of-aborting.patch && \
+RUN cp -a /root/files/${mono_version} /root && \
+    cd /root/${mono_version} && \
     export CMAKE=/root/osxcross/target/bin/x86_64-apple-darwin18-cmake && \
     NOCONFIGURE=1 ./autogen.sh && \
     ./configure --prefix=/root/dependencies/mono \
@@ -46,7 +42,7 @@ RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-bra
     mkdir -p /root/dependencies/mono/etc && \
     cp -rvp /etc/mono /root/dependencies/mono/etc/ && \
     cp /root/files/mono-config-macosx /root/dependencies/mono/etc/mono/config && \
-    rm -rf /root/mono
+    rm -rf /root/${mono_version}
 
 ENV MONO64_PREFIX=/root/dependencies/mono
 

--- a/Dockerfile.ubuntu-32
+++ b/Dockerfile.ubuntu-32
@@ -2,9 +2,11 @@ FROM i386/ubuntu:trusty
 
 ARG mono_version
 
-RUN if [ -z "${mono_version}" ]; then echo -e "\n\nArgument mono_version is mandatory!\n\n"; exit 1; fi && \
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN if [ -z "${mono_version}" ]; then printf "\n\nArgument mono_version is mandatory!\n\n"; exit 1; fi && \
     apt-get update && \
-    apt-get -y install wget && \
+    apt-get -y install wget --no-install-recommends && \
     cd /root && \
     wget -O- 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F' | apt-key add - && \
     wget -O- 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x8E51A6D660CD88D67D65221D90BD7EACED8E640A' | apt-key add - && \
@@ -18,7 +20,9 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nArgument mono_version is mand
     ln -sf /usr/bin/gcc-ranlib-8 /usr/bin/gcc-ranlib && \
     ln -sf /usr/bin/gcc-ar-8 /usr/bin/gcc-ar && \
     ln -sf /usr/bin/gcc-8 /usr/bin/gcc && \
-    ln -sf /usr/bin/g++-8 /usr/bin/g++
+    ln -sf /usr/bin/g++-8 /usr/bin/g++ && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN cp -a /root/files/${mono_version} /root && \
     cd /root/${mono_version} && \
@@ -33,11 +37,9 @@ RUN cp -a /root/files/${mono_version} /root && \
     wget https://download.mono-project.com/repo/ubuntu/pool/main/c/core-setup/msbuild-libhostfxr_3.0.0.2019.04.16.02.13-0xamarin3+ubuntu1604b1_i386.deb && \
     wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild-sdkresolver_16.3+xamarinxplat.2019.08.08.00.55-0xamarin2+ubuntu1604b1_all.deb && \
     wget https://download.mono-project.com/repo/ubuntu/pool/main/n/nuget/nuget_5.2.0.6090.bin-0xamarin1+ubuntu1604b1_all.deb && \
-    dpkg -i --force-all *.deb && \
+    dpkg -i --force-all ./*.deb && \
     sed -i '/Depends.*mono/d' /var/lib/dpkg/status && \
     ln -s /usr/bin/mono /usr/bin/cli && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/ && \
-    rm *.deb
+    rm ./*.deb
 
-CMD /bin/bash
+CMD ["/bin/bash"]

--- a/Dockerfile.ubuntu-32
+++ b/Dockerfile.ubuntu-32
@@ -1,9 +1,8 @@
 FROM i386/ubuntu:trusty
 
 ARG mono_version
-ARG mono_commit
 
-RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
+RUN if [ -z "${mono_version}" ]; then echo -e "\n\nArgument mono_version is mandatory!\n\n"; exit 1; fi && \
     apt-get update && \
     apt-get -y install wget && \
     cd /root && \
@@ -21,19 +20,15 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
     ln -sf /usr/bin/gcc-8 /usr/bin/gcc && \
     ln -sf /usr/bin/g++-8 /usr/bin/g++
 
-RUN cd /root && \
-    git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
-    cd /root/mono && \
-    if [ ! -z "${mono_commit}" ]; then git checkout ${mono_commit}; fi && \
-    git submodule update --init && \
-    git apply -3 /root/files/patches/mono-unity-Clear-TLS-instead-of-aborting.patch && \
+RUN cp -a /root/files/${mono_version} /root && \
+    cd /root/${mono_version} && \
     NOCONFIGURE=1 ./autogen.sh && \
     ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var/lib/mono --disable-boehm --host=i386-linux-gnu && \
     make -j && \
     make install && \
     cd /root && \
+    rm -rf /root/${mono_version} && \
     cert-sync /etc/ssl/certs/ca-certificates.crt && \
-    rm -rf /root/mono && \
     wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild_16.3+xamarinxplat.2019.08.08.00.55-0xamarin2+ubuntu1604b1_all.deb && \
     wget https://download.mono-project.com/repo/ubuntu/pool/main/c/core-setup/msbuild-libhostfxr_3.0.0.2019.04.16.02.13-0xamarin3+ubuntu1604b1_i386.deb && \
     wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild-sdkresolver_16.3+xamarinxplat.2019.08.08.00.55-0xamarin2+ubuntu1604b1_all.deb && \

--- a/Dockerfile.ubuntu-64
+++ b/Dockerfile.ubuntu-64
@@ -2,9 +2,11 @@ FROM ubuntu:trusty
 
 ARG mono_version
 
-RUN if [ -z "${mono_version}" ]; then echo -e "\n\nArgument mono_version is mandatory!\n\n"; exit 1; fi && \
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN if [ -z "${mono_version}" ]; then printf "\n\nArgument mono_version is mandatory!\n\n"; exit 1; fi && \
     apt-get update && \
-    apt-get -y install wget && \
+    apt-get -y install wget --no-install-recommends && \
     cd /root && \
     wget -O- 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F' | apt-key add - && \
     wget -O- 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x8E51A6D660CD88D67D65221D90BD7EACED8E640A' | apt-key add - && \
@@ -18,7 +20,9 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nArgument mono_version is mand
     ln -sf /usr/bin/gcc-ranlib-8 /usr/bin/gcc-ranlib && \
     ln -sf /usr/bin/gcc-ar-8 /usr/bin/gcc-ar && \
     ln -sf /usr/bin/gcc-8 /usr/bin/gcc && \
-    ln -sf /usr/bin/g++-8 /usr/bin/g++
+    ln -sf /usr/bin/g++-8 /usr/bin/g++ && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN cp -a /root/files/${mono_version} /root && \
     cd /root/${mono_version} && \
@@ -33,11 +37,9 @@ RUN cp -a /root/files/${mono_version} /root && \
     wget https://download.mono-project.com/repo/ubuntu/pool/main/c/core-setup/msbuild-libhostfxr_3.0.0.2019.04.16.02.13-0xamarin3+ubuntu1604b1_amd64.deb && \
     wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild-sdkresolver_16.3+xamarinxplat.2019.08.08.00.55-0xamarin2+ubuntu1604b1_all.deb && \
     wget https://download.mono-project.com/repo/ubuntu/pool/main/n/nuget/nuget_5.2.0.6090.bin-0xamarin1+ubuntu1604b1_all.deb && \
-    dpkg -i --force-all *.deb && \
+    dpkg -i --force-all ./*.deb && \
     sed -i '/Depends.*mono/d' /var/lib/dpkg/status && \
     ln -s /usr/bin/mono /usr/bin/cli && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/ && \
-    rm *.deb
+    rm ./*.deb
 
-CMD /bin/bash
+CMD ["/bin/bash"]

--- a/Dockerfile.ubuntu-64
+++ b/Dockerfile.ubuntu-64
@@ -1,9 +1,8 @@
 FROM ubuntu:trusty
 
 ARG mono_version
-ARG mono_commit
 
-RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
+RUN if [ -z "${mono_version}" ]; then echo -e "\n\nArgument mono_version is mandatory!\n\n"; exit 1; fi && \
     apt-get update && \
     apt-get -y install wget && \
     cd /root && \
@@ -21,19 +20,15 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
     ln -sf /usr/bin/gcc-8 /usr/bin/gcc && \
     ln -sf /usr/bin/g++-8 /usr/bin/g++
 
-RUN cd /root && \
-    git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
-    cd /root/mono && \
-    if [ ! -z "${mono_commit}" ]; then git checkout ${mono_commit}; fi && \
-    git submodule update --init && \
-    git apply -3 /root/files/patches/mono-unity-Clear-TLS-instead-of-aborting.patch && \
+RUN cp -a /root/files/${mono_version} /root && \
+    cd /root/${mono_version} && \
     NOCONFIGURE=1 ./autogen.sh && \
     ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var/lib/mono --disable-boehm --host=x86_64-linux-gnu && \
     make -j && \
     make install && \
     cd /root && \
+    rm -rf /root/${mono_version} && \
     cert-sync /etc/ssl/certs/ca-certificates.crt && \
-    rm -rf /root/mono && \
     wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild_16.3+xamarinxplat.2019.08.08.00.55-0xamarin2+ubuntu1604b1_all.deb && \
     wget https://download.mono-project.com/repo/ubuntu/pool/main/c/core-setup/msbuild-libhostfxr_3.0.0.2019.04.16.02.13-0xamarin3+ubuntu1604b1_amd64.deb && \
     wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild-sdkresolver_16.3+xamarinxplat.2019.08.08.00.55-0xamarin2+ubuntu1604b1_all.deb && \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -2,35 +2,37 @@ ARG img_version
 FROM godot-mono:${img_version}
 
 ARG mono_version
-ARG mono_commit
 
-RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
+RUN if [ -z "${mono_version}" ]; then echo -e "\n\nArgument mono_version is mandatory!\n\n"; exit 1; fi && \
     dnf -y install --setopt=install_weak_deps=False \
       mingw32-gcc mingw32-gcc-c++ mingw32-winpthreads-static mingw64-gcc mingw64-gcc-c++ mingw64-winpthreads-static yasm wine && \
-    dnf clean all && \
-    git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
-    cd /root/mono && \
-    if [ ! -z "${mono_commit}" ]; then git checkout ${mono_commit}; fi && \
-    git submodule update --init && \
-    git apply -3 /root/files/patches/mono-unity-Clear-TLS-instead-of-aborting.patch && \
-    git apply -3 /root/files/patches/wine-mono.patch && \
+    dnf clean packages && \
+    cp -a /root/files/${mono_version} /root && \
+    cd /root/${mono_version} && \
+    patch -p1 < /root/files/patches/wine-mono.patch && \
     export WINE_BITS=64 && \
-    bash /root/files/mono-build-win32.sh --prefix=/root/dependencies/mono-64 --host=x86_64-w64-mingw32 && \
-    git clean -fdx && \
+    bash -x /root/files/mono-build-win32.sh --prefix=/root/dependencies/mono-64 --host=x86_64-w64-mingw32 && \
+    cd /root && \
+    rm -rf /root/${mono_version} && \
     cp /root/dependencies/mono-64/bin/libMonoPosixHelper.dll /root/dependencies/mono-64/bin/MonoPosixHelper.dll && \
     rm -f /root/dependencies/mono-64/bin/mono /root/dependencies/mono-64/bin/mono-sgen && \
     ln -s /usr/bin/mono /root/dependencies/mono-64/bin/mono && \
     ln -s /usr/bin/mono-sgen /root/dependencies/mono-64/bin/mono-sgen && \
     cp -rvp /etc/mono /root/dependencies/mono-64/etc && \
+    \
+    cp -a /root/files/${mono_version} /root && \
+    cd /root/${mono_version} && \
+    patch -p1 < /root/files/patches/wine-mono.patch && \
     export WINE_BITS=32 && \
-    bash /root/files/mono-build-win32.sh --prefix=/root/dependencies/mono-32 --host=i686-w64-mingw32 && \
+    bash -x /root/files/mono-build-win32.sh --prefix=/root/dependencies/mono-32 --host=i686-w64-mingw32 && \
     cd /root && \
+    rm -rf /root/${mono_version} && \
     cp /root/dependencies/mono-32/bin/libMonoPosixHelper.dll /root/dependencies/mono-32/bin/MonoPosixHelper.dll && \
     rm -f /root/dependencies/mono-32/bin/mono /root/dependencies/mono-32/bin/mono-sgen && \
     ln -s /usr/bin/mono /root/dependencies/mono-32/bin/mono && \
     ln -s /usr/bin/mono-sgen /root/dependencies/mono-32/bin/mono-sgen && \
     cp -rvp /etc/mono /root/dependencies/mono-32/etc && \
-    rm -rf /root/mono && \
+    rpm -ev --nodeps --noscripts --notriggers avahi && \
     dnf -y remove wine
 
 ENV MONO32_PREFIX=/root/dependencies/mono-32

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -3,7 +3,7 @@ FROM godot-mono:${img_version}
 
 ARG mono_version
 
-RUN if [ -z "${mono_version}" ]; then echo -e "\n\nArgument mono_version is mandatory!\n\n"; exit 1; fi && \
+RUN if [ -z "${mono_version}" ]; then printf "\n\nArgument mono_version is mandatory!\n\n"; exit 1; fi && \
     dnf -y install --setopt=install_weak_deps=False \
       mingw32-gcc mingw32-gcc-c++ mingw32-winpthreads-static mingw64-gcc mingw64-gcc-c++ mingw64-winpthreads-static yasm wine && \
     dnf clean packages && \
@@ -38,4 +38,4 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nArgument mono_version is mand
 ENV MONO32_PREFIX=/root/dependencies/mono-32
 ENV MONO64_PREFIX=/root/dependencies/mono-64
 
-CMD /bin/bash
+CMD ["/bin/bash"]

--- a/Dockerfile.xcode
+++ b/Dockerfile.xcode
@@ -2,14 +2,14 @@ FROM godot-fedora:${img_version}
 
 RUN dnf -y install --setopt=install_weak_deps=False \
       autoconf automake libtool clang cmake fuse fuse-devel libxml2-devel libicu-devel compat-openssl10-devel bzip2-devel kmod cpio && \
-    dnf clean all && \
-    git clone https://github.com/mackyle/xar.git && \
+    dnf clean packages && \
+    git clone https://github.com/mackyle/xar.git --progress && \
     cd xar/xar && \
     git checkout 66d451dab1ef859dd0c83995f2379335d35e53c9 && \
     ./autogen.sh --prefix=/usr && \
     make -j && make install && \
     cd /root && \
-    git clone https://github.com/NiklasRosenstein/pbzx && \
+    git clone https://github.com/NiklasRosenstein/pbzx --progress && \
     cd pbzx && \
     git checkout 2a4d7c3300c826d918def713a24d25c237c8ed53 && \
     clang -O3 -llzma -lxar -I /usr/local/include pbzx.c -o pbzx

--- a/Dockerfile.xcode
+++ b/Dockerfile.xcode
@@ -1,5 +1,7 @@
 FROM godot-fedora:${img_version}
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 RUN dnf -y install --setopt=install_weak_deps=False \
       autoconf automake libtool clang cmake fuse fuse-devel libxml2-devel libicu-devel compat-openssl10-devel bzip2-devel kmod cpio && \
     dnf clean packages && \
@@ -12,9 +14,8 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     git clone https://github.com/NiklasRosenstein/pbzx --progress && \
     cd pbzx && \
     git checkout 2a4d7c3300c826d918def713a24d25c237c8ed53 && \
-    clang -O3 -llzma -lxar -I /usr/local/include pbzx.c -o pbzx
-
-CMD mkdir -p /root/xcode && \
+    clang -O3 -llzma -lxar -I /usr/local/include pbzx.c -o pbzx && \
+    mkdir -p /root/xcode && \
     cd /root/xcode && \
     xar -xf /root/files/Xcode_10.3.xip && \
     /root/pbzx/pbzx -n Content | cpio -i && \
@@ -41,3 +42,5 @@ CMD mkdir -p /root/xcode && \
     cp -r Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1 /tmp/iPhoneOS12.4.sdk/usr/include/c++/ && \
     cd /tmp && \
     tar -cJf /root/files/iPhoneSimulator12.4.sdk.tar.xz iPhoneOS12.4.sdk
+
+CMD ["/bin/bash"]

--- a/build.sh
+++ b/build.sh
@@ -105,7 +105,6 @@ if [ ! -e files/MacOSX10.14.sdk.tar.xz ] || [ ! -e files/iPhoneOS12.4.sdk.tar.xz
 
   echo "Building OSX and iOS SDK packages. This will take a while"
   $podman_build -t godot-xcode-packer:${img_version} -f Dockerfile.xcode -v ${files_root}:/root/files . 2>&1 | tee logs/xcode.log
-  $podman run -it --rm -v ${files_root}:/root/files godot-xcode-packer:${img_version} 2>&1 | tee logs/xcode_packer.log
 fi
 
 $podman_build -t godot-ios:${img_version} -f Dockerfile.ios -v ${files_root}:/root/files . 2>&1 | tee logs/ios.log

--- a/build.sh
+++ b/build.sh
@@ -1,38 +1,63 @@
 #!/bin/bash
-
 set -e
 
-podman=podman
-if ! which $podman; then
-  podman=docker
+podman=`which podman`
+if [ -z $podman ]; then
+  podman=`which docker`
 fi
 
-if ! which $podman; then
+if [ -z $podman ]; then
   echo "Either podman or docker need to be in PATH for this script to work."
   exit 1
 fi
 
-if [ -z "$1" ]; then
-  echo "usage: $0 <godot branch> <mono version string> [<mono branch> <mono commit hash>]"
+if [ -z "$1" -o -z "$2" ]; then
+  echo "Usage: $0 <godot branch> <mono version> [<mono branch> <mono commit hash>]"
   echo
   echo "Examples: $0 3.1 mono-5.18.1.3"
   echo "          $0 master mono-6.6.0.160 2019-08 bef1e6335812d32f8eab648c0228fc624b9f8357"
   echo
+  echo "godot branch:"
+  echo "mono version:"
+  echo "	These are combined to form the docker image tag, e.g. 'master-mono-6.6.0.160'."
+  echo "	Git will then clone the branch/tag that matches the mono version."
+  echo 
+  echo "mono branch:"
+  echo "	If specified, git will clone this mono branch/tag instead. Requires specifying a commit."
+  echo
+  echo "mono commit:"
+  echo "	If specified, git will check out this commit after cloning."
+  echo 
   exit 1
 fi
 
 godot_branch=$1
 mono_version=$2
 img_version=$godot_branch-$mono_version
+files_root=$(pwd)/files
 mono_commit=
+
+# If optional Mono git branch and commit hash were passed, use them.
 if [ ! -z "$3" -a ! -z "$4" ]; then
-  # Optional Mono git branch and commit hash were passed,
-  # use that for the git clones.
   mono_version=$3
   mono_commit=$4
 fi
-echo "Building images with version: ${img_version}"
-echo "Mono version used: ${mono_version} ${mono_commit}"
+
+# If mono branch does not start with mono-, prepend it to the folder name.
+if [ ${mono_version:0:5} != "mono-" ]; then
+
+	mono_root=${files_root}/"mono-${mono_version}"
+else
+	mono_root=${files_root}/${mono_version}
+fi
+
+# Confirm settings
+echo "Docker image tag: ${img_version}"
+echo "Mono branch: ${mono_version}"
+if [ ! -z "$mono_commit" ]; then
+	echo "Mono commit: ${mono_commit}"
+fi
+echo "Mono source folder: ${mono_root}"
 echo
 while true; do
     read -p "Is this correct? [y/n] " yn
@@ -45,8 +70,20 @@ done
 
 mkdir -p logs
 
+# Check out and patch Mono version
+if [ ! -e ${mono_root} ]; then
+    git clone https://github.com/mono/mono ${mono_root} --branch ${mono_version} --single-branch --progress --depth 1 
+    pushd ${mono_root}
+    if [ ! -z "${mono_commit}" ]; then 
+	git checkout ${mono_commit} 
+    fi
+    git submodule update --init --recursive --recommend-shallow --progress --depth 1 
+    patch -p1 < ${files_root}/patches/mono-unity-Clear-TLS-instead-of-aborting.patch 
+    popd
+fi
+
 export podman_build="$podman build --build-arg img_version=${img_version}"
-export podman_build_mono="$podman_build --build-arg mono_version=${mono_version} --build-arg mono_commit=${mono_commit} -v $(pwd)/files:/root/files"
+export podman_build_mono="$podman_build --build-arg mono_version=${mono_version} -v ${files_root}:/root/files"
 
 $podman build -t godot-fedora:${img_version} -f Dockerfile.base . 2>&1 | tee logs/base.log
 $podman_build -t godot-export:${img_version} -f Dockerfile.export . 2>&1 | tee logs/export.log
@@ -54,12 +91,11 @@ $podman_build -t godot-export:${img_version} -f Dockerfile.export . 2>&1 | tee l
 $podman_build_mono -t godot-mono:${img_version} -f Dockerfile.mono . 2>&1 | tee logs/mono.log
 $podman_build_mono -t godot-mono-glue:${img_version} -f Dockerfile.mono-glue . 2>&1 | tee logs/mono-glue.log
 $podman_build_mono -t godot-windows:${img_version} -f Dockerfile.windows --ulimit nofile=65536 . 2>&1 | tee logs/windows.log
+
 $podman_build_mono -t godot-ubuntu-64:${img_version} -f Dockerfile.ubuntu-64 . 2>&1 | tee logs/ubuntu-64.log
 $podman_build_mono -t godot-ubuntu-32:${img_version} -f Dockerfile.ubuntu-32 . 2>&1 | tee logs/ubuntu-32.log
-$podman_build_mono -t godot-android:${img_version} -f Dockerfile.android . 2>&1 | tee logs/android.log
 $podman_build_mono -t godot-javascript:${img_version} -f Dockerfile.javascript . 2>&1 | tee logs/javascript.log
-
-$podman_build -t godot-xcode-packer:${img_version} -f Dockerfile.xcode -v $(pwd)/files:/root/files . 2>&1 | tee logs/xcode.log
+$podman_build_mono -t godot-android:${img_version} -f Dockerfile.android . 2>&1 | tee logs/android.log
 
 if [ ! -e files/MacOSX10.14.sdk.tar.xz ] || [ ! -e files/iPhoneOS12.4.sdk.tar.xz ] || [ ! -e files/iPhoneSimulator12.4.sdk.tar.xz ]; then
   if [ ! -e files/Xcode_10.3.xip ]; then
@@ -68,10 +104,11 @@ if [ ! -e files/MacOSX10.14.sdk.tar.xz ] || [ ! -e files/iPhoneOS12.4.sdk.tar.xz
   fi
 
   echo "Building OSX and iOS SDK packages. This will take a while"
-  $podman run -it --rm -v $(pwd)/files:/root/files godot-xcode-packer:${img_version} 2>&1 | tee logs/xcode_packer.log
+  $podman_build -t godot-xcode-packer:${img_version} -f Dockerfile.xcode -v ${files_root}:/root/files . 2>&1 | tee logs/xcode.log
+  $podman run -it --rm -v ${files_root}:/root/files godot-xcode-packer:${img_version} 2>&1 | tee logs/xcode_packer.log
 fi
 
-$podman_build -t godot-ios:${img_version} -f Dockerfile.ios -v $(pwd)/files:/root/files . 2>&1 | tee logs/ios.log
+$podman_build -t godot-ios:${img_version} -f Dockerfile.ios -v ${files_root}:/root/files . 2>&1 | tee logs/ios.log
 $podman_build_mono -t godot-osx:${img_version} -f Dockerfile.osx . 2>&1 | tee logs/osx.log
 
 if [ ! -e files/msvc2017.tar ]; then
@@ -86,4 +123,4 @@ if [ ! -e files/msvc2017.tar ]; then
   exit 1
 fi
 
-$podman_build -t godot-msvc:${img_version} -f Dockerfile.msvc -v $(pwd)/files:/root/files . 2>&1 | tee logs/msvc.log
+$podman_build -t godot-msvc:${img_version} -f Dockerfile.msvc -v ${files_root}:/root/files . 2>&1 | tee logs/msvc.log

--- a/files/mono-build-win32.sh
+++ b/files/mono-build-win32.sh
@@ -17,7 +17,7 @@ export PATH="$(pwd)/.bin/:$PATH"
 ./autogen.sh $@ --disable-boehm --with-mcs-docs=no HOST_PROFILE=win32
 echo '#define HAVE_STRUCT_SOCKADDR_IN6 1' >> config.h
 pushd mcs/jay
-make CC=gcc
+make CC=gcc BUILD_PLATFORM=win32
 popd
 
 for dir in external/roslyn-binaries/Microsoft.Net.Compilers/[0-9]*; do
@@ -25,5 +25,5 @@ for dir in external/roslyn-binaries/Microsoft.Net.Compilers/[0-9]*; do
 done
 export MONO_PATH
 
-make -j
-make install
+make -j SHELL='bash -x'
+make install SHELL='bash -x'


### PR DESCRIPTION
This PR fixes problems in Dockerfile.windows, and removes a lot of redundant downloading and processing.

Fixes #37 

* Reduces downloading mono and ~25 submodules from 7x to once (and saves on re-runs)
* Reduces dnf cache downloads from 11x to once (dnf cleans packages only, retaining cache)
* Reduces git clone/submodule downloads by downloading shallow repos where possible (`--depth 1`)
* Adds progress indicator to all git clones
* Fixes patching. `git apply` seems less reliable and will reject everything if anything is the tiniest bit off. Patch works in chunks and will patch what it can. It has more tolerance for changes, e.g. line number changes. 2 of 3 `git apply` commands failed. `patch -p1 < file` worked. Replaced all three patch commands.
* Moves building xcode-packer into `if ! -e macos sdk`. Build repo only if needed.
* Dockerfile.windows:
    * Fixes can't find libstdc++.so.6 and libc.so.6 (not sure how, but giving it a clean repo between bit versions helped a lot of failures)
   * Bash scripts and Make now print out every command so errors are easier to track
   * Fixes `dnf remove wine` hanging on avahi scriptlet
   * Fixes building Jay



I just built all new images. But why is android so big?! Now it's 5gb bigger than before!

```
localhost/godot-android        3.2-mono-6.6.0.166   fa87ed0c9068   3 minutes ago   17 GB
localhost/godot-xcode-packer   3.2-mono-6.6.0.166   a63d2620acdf   3 hours ago     1.03 GB
localhost/godot-ios            3.2-mono-6.6.0.166   0758942928de   17 hours ago    1.88 GB
localhost/godot-javascript     3.2-mono-6.6.0.166   fb34f8055402   19 hours ago    2.83 GB
localhost/godot-ubuntu-32      3.2-mono-6.6.0.166   f657b619d48d   20 hours ago    994 MB
localhost/godot-ubuntu-64      3.2-mono-6.6.0.166   3b16c95d9cee   20 hours ago    1.07 GB
localhost/godot-windows        3.2-mono-6.6.0.166   afc2f33e1efb   21 hours ago    3.45 GB
localhost/godot-mono-glue      3.2-mono-6.6.0.166   d3f36cbf40d2   23 hours ago    1.57 GB
localhost/godot-mono           3.2-mono-6.6.0.166   858d6311024b   23 hours ago    1.36 GB
localhost/godot-export         3.2-mono-6.6.0.166   174885334dde   24 hours ago    949 MB
localhost/godot-fedora         3.2-mono-6.6.0.166   1810aa32f22b   24 hours ago    564 MB
docker.io/library/fedora       31                   536f3995adeb   2 weeks ago     200 MB

---
Large android folders in /root:
8.9G    android-toolchains
1.5G    mono-configs
98M     mono-installs
4.1G    sdk

1.3G    /usr
```

--- 
Second commit, I ran http://github.com/hadolint/hadolint per calinou. This resulted in 45 best practices warnings. I fixed all except for using WORKDIR instead of cd, and pinning apt-get installs (and dnf) to specific versions).
```
DL3003 Use WORKDIR to switch to a directory
DL3008 Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
```

Key takeaways:
* Any docker that uses `|` should have `SHELL ["/bin/bash", "-o", "pipefail", "-c"]` before RUN so it will fail if either side of the pipe fails.
* Globs `*.deb` should begin with `./*.deb` in case a file begins with a hyphen so it's not interpreted as an option.
* `-e` on `echo` is not a POSIX standard and printf is recommended.
* `CMD` is a json list, so should be formatted as `CMD ["/bin/bash"]`
* Because of the above, I combined xcode RUN and CMD into one command and removed the redundant line in build.sh

 
