### PR TITLE
Optimize mono & dnf downloads

### DIFF
--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -2,12 +2,10 @@ ARG img_version
 FROM godot-mono:${img_version}
 
 ARG mono_version
-ARG mono_commit
 
 RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
     dnf -y install --setopt=install_weak_deps=False \
       gcc gcc-c++ java-1.8.0-openjdk-devel ncurses-compat-libs && \
-    dnf clean all && \
     mkdir sdk && cd sdk && \
     curl -LO https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip && \
     unzip sdk-tools-linux-4333796.zip && \
@@ -18,23 +16,19 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
 ENV ANDROID_HOME=/root/sdk/
 ENV ANDROID_NDK_ROOT=/root/sdk/ndk-bundle/
 
-RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
-    cd /root/mono && \
-    if [ ! -z "${mono_commit}" ]; then git checkout ${mono_commit}; fi && \
-    git submodule update --init && \
-    git apply -3 /root/files/patches/mono-unity-Clear-TLS-instead-of-aborting.patch && \
-    export MONO_SOURCE_ROOT=/root/mono && \
+RUN cp -a /root/files/${mono_version} /root && \
+    export MONO_SOURCE_ROOT=/root/${mono_version} && \
     export make="make -j" && \
-    git clone https://github.com/godotengine/godot-mono-builds /root/godot-mono-builds && \
+    git clone --progress https://github.com/godotengine/godot-mono-builds /root/godot-mono-builds && \
     cd /root/godot-mono-builds && \
     git checkout 710b275fbf29ddb03fd5285c51782951a110cdab && \
     python3 patch_mono.py && \
     python3 android.py configure --target=all-runtime && \
     python3 android.py make --target=all-runtime && \
-    cd /root/mono && git clean -fdx && NOCONFIGURE=1 ./autogen.sh && \
+    cd /root/${mono_version} && git clean -fdx && NOCONFIGURE=1 ./autogen.sh && \
     cd /root/godot-mono-builds && \
     python3 bcl.py make --product=android && \
     cd /root && \
-    rm -rf /root/mono /root/godot-mono-builds
+    rm -rf /root/${mono_version} /root/godot-mono-builds
 
 CMD /bin/bash

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -4,7 +4,6 @@ WORKDIR /root
 
 RUN dnf -y upgrade --setopt=install_weak_deps=False && \
     dnf -y install --setopt=install_weak_deps=False \
-      bash bzip2 curl git make patch pkgconfig python3 scons unzip which xz && \
-    dnf clean all
+      bash bzip2 curl git make patch pkgconfig python3 scons unzip which xz
 
-CMD /bin/true
+CMD /bin/bash

--- a/Dockerfile.export
+++ b/Dockerfile.export
@@ -2,7 +2,6 @@ ARG img_version
 FROM godot-fedora:${img_version}
 
 RUN dnf -y install --setopt=install_weak_deps=False \
-      xorg-x11-server-Xvfb mesa-dri-drivers libXcursor libXinerama libXrandr libXi alsa-lib pulseaudio-libs java-1.8.0-openjdk-devel && \
-    dnf clean all
+      xorg-x11-server-Xvfb mesa-dri-drivers libXcursor libXinerama libXrandr libXi alsa-lib pulseaudio-libs java-1.8.0-openjdk-devel
 
 CMD /bin/bash

--- a/Dockerfile.ios
+++ b/Dockerfile.ios
@@ -3,8 +3,7 @@ FROM godot-fedora:${img_version}
 
 RUN dnf -y install --setopt=install_weak_deps=False \
       automake autoconf clang gcc gcc-c++ gcc-objc gcc-objc++ cmake libicu-devel libtool libxml2-devel llvm-devel openssl-devel perl python yasm && \
-    dnf clean all && \
-    git clone https://github.com/tpoechtrager/cctools-port.git && \
+    git clone --progress https://github.com/tpoechtrager/cctools-port.git && \
     cd /root/cctools-port && \
     git checkout 8239a5211bcf07d6b9d359782e1a889ec1d7cce5 && \
     sed -i 's#./autogen.sh#libtoolize -c -i --force\n./autogen.sh#' usage_examples/ios_toolchain/build.sh && \

--- a/Dockerfile.javascript
+++ b/Dockerfile.javascript
@@ -2,36 +2,32 @@ ARG img_version
 FROM godot-mono:${img_version}
 
 ARG mono_version
-ARG mono_commit
 
-RUN dnf -y install --setopt=install_weak_deps=False \
+RUN if [ -z "${mono_version}" ]; then printf "\n\nArgument mono_version is mandatory!\n\n"; exit 1; fi && \
+    dnf -y install --setopt=install_weak_deps=False \
       java-openjdk yasm && \
-    dnf clean all && \
-    git clone https://github.com/emscripten-core/emsdk && \
+    git clone --progress https://github.com/emscripten-core/emsdk && \
     cd emsdk && \
     git checkout a5082b232617c762cb65832429f896c838df2483 && \
     ./emsdk install 1.38.47-upstream && \
     ./emsdk activate 1.38.47-upstream && \
     echo "source /root/emsdk/emsdk_env.sh" >> /root/.bashrc
 
-RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
-    cd /root/mono && \
-    if [ ! -z "${mono_commit}" ]; then git checkout ${mono_commit}; fi && \
-    git submodule update --init && \
-    git apply -3 /root/files/patches/mono-unity-Clear-TLS-instead-of-aborting.patch && \
-    git apply -3 /root/files/patches/mono-pr16636-wasm-bugfix-and-update.diff && \
-    export MONO_SOURCE_ROOT=/root/mono && \
+RUN cp -a /root/files/${mono_version} /root && \
+    cd /root/${mono_version} && \
+    patch -p1 < /root/files/patches/mono-pr16636-wasm-bugfix-and-update.diff && \
+    export MONO_SOURCE_ROOT=/root/${mono_version} && \
     export make="make -j" && \
-    git clone https://github.com/godotengine/godot-mono-builds /root/godot-mono-builds && \
+    git clone --progress https://github.com/godotengine/godot-mono-builds /root/godot-mono-builds && \
     cd /root/godot-mono-builds && \
     git checkout 710b275fbf29ddb03fd5285c51782951a110cdab && \
     python3 patch_emscripten.py && \
     python3 wasm.py configure --target=runtime && \
     python3 wasm.py make --target=runtime && \
-    cd /root/mono && git clean -fdx && NOCONFIGURE=1 ./autogen.sh && \
+    cd /root/${mono_version} && git clean -fdx && NOCONFIGURE=1 ./autogen.sh && \
     cd /root/godot-mono-builds && \
     python3 bcl.py make --product wasm && \
     cd /root && \
-    rm -rf /root/mono /root/godot-mono-builds
+    rm -rf /root/${mono_version} /root/godot-mono-builds
 
 CMD /bin/bash

--- a/Dockerfile.mono
+++ b/Dockerfile.mono
@@ -2,28 +2,23 @@ ARG img_version
 FROM godot-fedora:${img_version}
 
 ARG mono_version
-ARG mono_commit
 
 RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
     dnf -y install --setopt=install_weak_deps=False \
       autoconf automake cmake gcc gcc-c++ gettext libtool perl python && \
-    dnf clean all && \
-    git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
-    cd /root/mono && \
-    if [ ! -z "${mono_commit}" ]; then git checkout ${mono_commit}; fi && \
-    git submodule update --init && \
-    git apply -3 /root/files/patches/mono-unity-Clear-TLS-instead-of-aborting.patch && \
+    cp -a /root/files/${mono_version} /root && \
+    cd /root/${mono_version} && \
     NOCONFIGURE=1 ./autogen.sh && \
     ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var/lib/mono --disable-boehm && \
     make -j && \
     make install && \
     cd /root && \
+    rm -rf /root/${mono_version} && \
     cert-sync /etc/pki/tls/certs/ca-bundle.crt && \
     rpm -ivh --nodeps \
       https://download.mono-project.com/repo/centos8-stable/m/msbuild/msbuild-16.3+xamarinxplat.2019.08.08.00.55-0.xamarin.2.epel8.noarch.rpm \
       https://download.mono-project.com/repo/centos8-stable/m/msbuild-libhostfxr/msbuild-libhostfxr-3.0.0.2019.04.16.02.13-0.xamarin.4.epel8.x86_64.rpm \
       https://download.mono-project.com/repo/centos8-stable/m/msbuild/msbuild-sdkresolver-16.3+xamarinxplat.2019.08.08.00.55-0.xamarin.2.epel8.noarch.rpm \
-      https://download.mono-project.com/repo/centos8-stable/n/nuget/nuget-5.2.0.6090.bin-0.xamarin.1.epel8.noarch.rpm && \
-    rm -rf /root/mono
+      https://download.mono-project.com/repo/centos8-stable/n/nuget/nuget-5.2.0.6090.bin-0.xamarin.1.epel8.noarch.rpm
 
 CMD /bin/bash

--- a/Dockerfile.mono-glue
+++ b/Dockerfile.mono-glue
@@ -2,10 +2,8 @@ ARG img_version
 FROM godot-mono:${img_version}
 
 ARG mono_version
-ARG mono_commit
 
 RUN dnf -y install --setopt=install_weak_deps=False \
-      xorg-x11-server-Xvfb libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel libXi-devel alsa-lib-devel pulseaudio-libs-devel libudev-devel mesa-libGL-devel mesa-libGLU-devel mesa-dri-drivers && \
-    dnf clean all
+      xorg-x11-server-Xvfb libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel libXi-devel alsa-lib-devel pulseaudio-libs-devel libudev-devel mesa-libGL-devel mesa-libGLU-devel mesa-dri-drivers
 
 CMD /bin/bash

--- a/Dockerfile.msvc
+++ b/Dockerfile.msvc
@@ -5,7 +5,6 @@ ENV WINEDEBUG=-all
 
 RUN dnf -y install --setopt=install_weak_deps=False \
       wine winetricks xorg-x11-server-Xvfb p7zip-plugins findutils && \
-    dnf clean all && \
     curl -LO https://github.com/GodotBuilder/godot-builds/releases/download/_tools/angle.7z && \
     curl -LO https://www.python.org/ftp/python/3.7.2/python-3.7.2-amd64.exe && \
     xvfb-run sh -c "winetricks -q vcrun2017; wineserver -w" ;\

--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -2,13 +2,11 @@ ARG img_version
 FROM godot-mono:${img_version}
 
 ARG mono_version
-ARG mono_commit
 
 RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
     dnf -y install --setopt=install_weak_deps=False \
       automake autoconf bzip2-devel clang libicu-devel libtool libxml2-devel llvm-devel openssl-devel yasm && \
-    dnf clean all && \
-    git clone https://github.com/tpoechtrager/osxcross.git && \
+    git clone --progress https://github.com/tpoechtrager/osxcross.git && \
     cd /root/osxcross && \
     git checkout 542acc2ef6c21aeb3f109c03748b1015a71fed63 && \
     ln -s /root/files/MacOSX10.14.sdk.tar.xz /root/osxcross/tarballs && \
@@ -17,11 +15,8 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
 ENV OSXCROSS_ROOT=/root/osxcross
 ENV PATH="/root/osxcross/target/bin:${PATH}"
 
-RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
-    cd /root/mono && \
-    if [ ! -z "${mono_commit}" ]; then git checkout ${mono_commit}; fi && \
-    git submodule update --init && \
-    git apply -3 /root/files/patches/mono-unity-Clear-TLS-instead-of-aborting.patch && \
+RUN cp -a /root/files/${mono_version} /root && \
+    cd /root/${mono_version} && \
     export CMAKE=/root/osxcross/target/bin/x86_64-apple-darwin18-cmake && \
     NOCONFIGURE=1 ./autogen.sh && \
     ./configure --prefix=/root/dependencies/mono \
@@ -46,8 +41,6 @@ RUN git clone https://github.com/mono/mono --branch ${mono_version} --single-bra
     mkdir -p /root/dependencies/mono/etc && \
     cp -rvp /etc/mono /root/dependencies/mono/etc/ && \
     cp /root/files/mono-config-macosx /root/dependencies/mono/etc/mono/config && \
-    rm -rf /root/mono
-
-ENV MONO64_PREFIX=/root/dependencies/mono
+    rm -rf /root/${mono_version}
 
 CMD /bin/bash

--- a/Dockerfile.ubuntu-32
+++ b/Dockerfile.ubuntu-32
@@ -1,7 +1,6 @@
 FROM i386/ubuntu:trusty
 
 ARG mono_version
-ARG mono_commit
 
 RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
     apt-get update && \
@@ -21,19 +20,15 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
     ln -sf /usr/bin/gcc-8 /usr/bin/gcc && \
     ln -sf /usr/bin/g++-8 /usr/bin/g++
 
-RUN cd /root && \
-    git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
-    cd /root/mono && \
-    if [ ! -z "${mono_commit}" ]; then git checkout ${mono_commit}; fi && \
-    git submodule update --init && \
-    git apply -3 /root/files/patches/mono-unity-Clear-TLS-instead-of-aborting.patch && \
+RUN cp -a /root/files/${mono_version} /root && \
+    cd /root/${mono_version} && \
     NOCONFIGURE=1 ./autogen.sh && \
     ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var/lib/mono --disable-boehm --host=i386-linux-gnu && \
     make -j && \
     make install && \
     cd /root && \
+    rm -rf /root/${mono_version} && \
     cert-sync /etc/ssl/certs/ca-certificates.crt && \
-    rm -rf /root/mono && \
     wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild_16.3+xamarinxplat.2019.08.08.00.55-0xamarin2+ubuntu1604b1_all.deb && \
     wget https://download.mono-project.com/repo/ubuntu/pool/main/c/core-setup/msbuild-libhostfxr_3.0.0.2019.04.16.02.13-0xamarin3+ubuntu1604b1_i386.deb && \
     wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild-sdkresolver_16.3+xamarinxplat.2019.08.08.00.55-0xamarin2+ubuntu1604b1_all.deb && \

--- a/Dockerfile.ubuntu-64
+++ b/Dockerfile.ubuntu-64
@@ -1,7 +1,6 @@
 FROM ubuntu:trusty
 
 ARG mono_version
-ARG mono_commit
 
 RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
     apt-get update && \
@@ -21,19 +20,15 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
     ln -sf /usr/bin/gcc-8 /usr/bin/gcc && \
     ln -sf /usr/bin/g++-8 /usr/bin/g++
 
-RUN cd /root && \
-    git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
-    cd /root/mono && \
-    if [ ! -z "${mono_commit}" ]; then git checkout ${mono_commit}; fi && \
-    git submodule update --init && \
-    git apply -3 /root/files/patches/mono-unity-Clear-TLS-instead-of-aborting.patch && \
+RUN cp -a /root/files/${mono_version} /root && \
+    cd /root/${mono_version} && \
     NOCONFIGURE=1 ./autogen.sh && \
     ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var/lib/mono --disable-boehm --host=x86_64-linux-gnu && \
     make -j && \
     make install && \
     cd /root && \
+    rm -rf /root/${mono_version} && \
     cert-sync /etc/ssl/certs/ca-certificates.crt && \
-    rm -rf /root/mono && \
     wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild_16.3+xamarinxplat.2019.08.08.00.55-0xamarin2+ubuntu1604b1_all.deb && \
     wget https://download.mono-project.com/repo/ubuntu/pool/main/c/core-setup/msbuild-libhostfxr_3.0.0.2019.04.16.02.13-0xamarin3+ubuntu1604b1_amd64.deb && \
     wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild-sdkresolver_16.3+xamarinxplat.2019.08.08.00.55-0xamarin2+ubuntu1604b1_all.deb && \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -2,18 +2,13 @@ ARG img_version
 FROM godot-mono:${img_version}
 
 ARG mono_version
-ARG mono_commit
 
 RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
     dnf -y install --setopt=install_weak_deps=False \
       mingw32-gcc mingw32-gcc-c++ mingw32-winpthreads-static mingw64-gcc mingw64-gcc-c++ mingw64-winpthreads-static yasm wine && \
-    dnf clean all && \
-    git clone https://github.com/mono/mono --branch ${mono_version} --single-branch && \
-    cd /root/mono && \
-    if [ ! -z "${mono_commit}" ]; then git checkout ${mono_commit}; fi && \
-    git submodule update --init && \
-    git apply -3 /root/files/patches/mono-unity-Clear-TLS-instead-of-aborting.patch && \
-    git apply -3 /root/files/patches/wine-mono.patch && \
+    cp -a /root/files/${mono_version} /root && \
+    cd /root/${mono_version} && \
+    patch -p1 < /root/files/patches/wine-mono.patch && \
     export WINE_BITS=64 && \
     bash /root/files/mono-build-win32.sh --prefix=/root/dependencies/mono-64 --host=x86_64-w64-mingw32 && \
     git clean -fdx && \
@@ -25,15 +20,12 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
     export WINE_BITS=32 && \
     bash /root/files/mono-build-win32.sh --prefix=/root/dependencies/mono-32 --host=i686-w64-mingw32 && \
     cd /root && \
+    rm -rf /root/${mono_version} && \
     cp /root/dependencies/mono-32/bin/libMonoPosixHelper.dll /root/dependencies/mono-32/bin/MonoPosixHelper.dll && \
     rm -f /root/dependencies/mono-32/bin/mono /root/dependencies/mono-32/bin/mono-sgen && \
     ln -s /usr/bin/mono /root/dependencies/mono-32/bin/mono && \
     ln -s /usr/bin/mono-sgen /root/dependencies/mono-32/bin/mono-sgen && \
     cp -rvp /etc/mono /root/dependencies/mono-32/etc && \
-    rm -rf /root/mono && \
     dnf -y remove wine
-
-ENV MONO32_PREFIX=/root/dependencies/mono-32
-ENV MONO64_PREFIX=/root/dependencies/mono-64
 
 CMD /bin/bash

--- a/Dockerfile.xcode
+++ b/Dockerfile.xcode
@@ -2,14 +2,13 @@ FROM godot-fedora:${img_version}
 
 RUN dnf -y install --setopt=install_weak_deps=False \
       autoconf automake libtool clang cmake fuse fuse-devel libxml2-devel libicu-devel compat-openssl10-devel bzip2-devel kmod cpio && \
-    dnf clean all && \
-    git clone https://github.com/mackyle/xar.git && \
+    git clone --progress https://github.com/mackyle/xar.git && \
     cd xar/xar && \
     git checkout 66d451dab1ef859dd0c83995f2379335d35e53c9 && \
     ./autogen.sh --prefix=/usr && \
     make -j && make install && \
     cd /root && \
-    git clone https://github.com/NiklasRosenstein/pbzx && \
+    git clone --progress https://github.com/NiklasRosenstein/pbzx && \
     cd pbzx && \
     git checkout 2a4d7c3300c826d918def713a24d25c237c8ed53 && \
     clang -O3 -llzma -lxar -I /usr/local/include pbzx.c -o pbzx


### PR DESCRIPTION
* Moves mono downloads from dockers to build.sh
* Retains dnf cache
* Adds progress to git downloads
* Replaces `git apply` with more reliable `patch`

Should address relevant notes in reference #38 

Note: `dnf clean all` became `dnf clean packages` to save dnf cache and only remove the packages. However the [default dnf configuration](https://dnf.readthedocs.io/en/latest/conf_ref.html) doesn't save the packages. keepcache=false is the default and must be set true in `/etc/dnf/dnf.con` in order to save packages. So `dnf clean` is removed entirely everywhere.