### PR TITLE
Wasm: Fix mono patch application on Emscripten 1.38.47

### DIFF
--- a/Dockerfile.javascript
+++ b/Dockerfile.javascript
@@ -16,6 +16,7 @@ RUN if [ -z "${mono_version}" ]; then printf "\n\nArgument mono_version is manda
 RUN cp -a /root/files/${mono_version} /root && \
     cd /root/${mono_version} && \
     patch -p1 < /root/files/patches/mono-pr16636-wasm-bugfix-and-update.diff && \
+    patch -p1 < /root/files/patches/mono-pr17094-bump-emscripten-1.38.46.patch && \
     export MONO_SOURCE_ROOT=/root/${mono_version} && \
     export make="make -j" && \
     git clone --progress https://github.com/godotengine/godot-mono-builds /root/godot-mono-builds && \

--- a/files/patches/mono-pr17094-bump-emscripten-1.38.46.patch
+++ b/files/patches/mono-pr17094-bump-emscripten-1.38.46.patch
@@ -1,0 +1,54 @@
+From 0ed3f281bf0dbcc138ad90f1f4f5e746baf2e088 Mon Sep 17 00:00:00 2001
+From: Zoltan Varga <vargaz@gmail.com>
+Date: Thu, 26 Sep 2019 18:21:50 -0400
+Subject: [PATCH] [wasm] Bump emscripten to 1.38.46.
+
+---
+ sdks/builds/emscripten-pr-8457.diff | 12 ++----------
+ sdks/builds/wasm.mk                 |  2 +-
+ 2 files changed, 3 insertions(+), 11 deletions(-)
+
+diff --git a/sdks/builds/emscripten-pr-8457.diff b/sdks/builds/emscripten-pr-8457.diff
+index 360af836be69..e6ae67952b80 100644
+--- a/sdks/builds/emscripten-pr-8457.diff
++++ b/sdks/builds/emscripten-pr-8457.diff
+@@ -15,24 +15,16 @@
+          if file_suffix in SOURCE_ENDINGS + BITCODE_ENDINGS + DYNAMICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS or shared.Building.is_ar(arg): # we already removed -o <target>, so all these should be inputs
+            newargs[i] = ''
+ -          if file_suffix.endswith(SOURCE_ENDINGS):
+-+          if file_suffix.endswith(SOURCE_ENDINGS) or (has_dash_c and file_suffix.endswith(BITCODE_ENDINGS)):
+++          if file_suffix.endswith(SOURCE_ENDINGS) or (has_dash_c and file_suffix.endswith(OBJECT_FILE_ENDINGS)):
+              input_files.append((i, arg))
+              has_source_inputs = True
+            elif file_suffix.endswith(HEADER_ENDINGS):
+-@@ -984,7 +987,6 @@
+- 
+-     newargs = [a for a in newargs if a != '']
+- 
+--    has_dash_c = '-c' in newargs
+-     has_dash_S = '-S' in newargs
+-     if has_dash_c or has_dash_S:
+-       assert has_source_inputs or has_header_inputs, 'Must have source code or header inputs to use -c or -S'
+ @@ -1838,7 +1840,7 @@
+        # First, generate LLVM bitcode. For each input file, we get base.o with bitcode
+        for i, input_file in input_files:
+          file_ending = get_file_suffix(input_file)
+ -        if file_ending.endswith(SOURCE_ENDINGS):
+-+        if file_ending.endswith(SOURCE_ENDINGS) or (has_dash_c and file_ending.endswith(BITCODE_ENDINGS)):
+++        if file_ending.endswith(SOURCE_ENDINGS) or (has_dash_c and file_ending.endswith(OBJECT_FILE_ENDINGS)):
+            compile_source_file(i, input_file)
+          else: # bitcode
+            if file_ending.endswith(BITCODE_ENDINGS):
+diff --git a/sdks/builds/wasm.mk b/sdks/builds/wasm.mk
+index e8c6692c45ac..757a35028395 100644
+--- a/sdks/builds/wasm.mk
++++ b/sdks/builds/wasm.mk
+@@ -1,7 +1,7 @@
+ #emcc has lots of bash'isms
+ SHELL:=/bin/bash
+ 
+-EMSCRIPTEN_VERSION=1.38.43
++EMSCRIPTEN_VERSION=1.38.46
+ EMSCRIPTEN_LOCAL_SDK_DIR=$(TOP)/sdks/builds/toolchains/emsdk
+ 
+ EMSCRIPTEN_SDK_DIR ?= $(EMSCRIPTEN_LOCAL_SDK_DIR)


### PR DESCRIPTION
As a reminder, we pinned the Emscripten version to `1.38.47-upstream` as we had a regression with wasm generation in 1.38.48 and 1.39.x back in 17666f07fe.

This patch comes from Mono's `2019-10` branch (6.8.x): https://github.com/mono/mono/pull/17094
(Slightly amended to include a version bump in `wasm.mk` that should have been done by other intermediate patches.)

We might need a recent Emscripten 1.39.x in the `3.2` branch eventually (CC @Faless), so we might have to consider upgrading to a newer Mono branch with support for a more recent Emscripten.