### PR TITLE
Use parallel make in godot-mono-builds scripts

### DIFF
--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -18,13 +18,12 @@ ENV ANDROID_NDK_ROOT=/root/sdk/ndk-bundle/
 
 RUN cp -a /root/files/${mono_version} /root && \
     export MONO_SOURCE_ROOT=/root/${mono_version} && \
-    export make="make -j" && \
     cd /root/${mono_version}/godot-mono-builds && \
-    python3 android.py configure --target=all-runtime && \
-    python3 android.py make --target=all-runtime && \
+    python3 android.py configure -j --target=all-runtime && \
+    python3 android.py make -j --target=all-runtime && \
     cd /root/${mono_version} && git clean -fdx && NOCONFIGURE=1 ./autogen.sh && \
     cd /root/${mono_version}/godot-mono-builds && \
-    python3 bcl.py make --product=android && \
+    python3 bcl.py make -j --product=android && \
     cd /root && \
     rm -rf /root/${mono_version}
 

--- a/Dockerfile.javascript
+++ b/Dockerfile.javascript
@@ -18,14 +18,13 @@ RUN cp -a /root/files/${mono_version} /root && \
     patch -p1 < /root/files/patches/mono-pr16636-wasm-bugfix-and-update.diff && \
     patch -p1 < /root/files/patches/mono-pr17094-bump-emscripten-1.38.46.patch && \
     export MONO_SOURCE_ROOT=/root/${mono_version} && \
-    export make="make -j" && \
     cd /root/${mono_version}/godot-mono-builds && \
     python3 patch_emscripten.py && \
-    python3 wasm.py configure --target=runtime && \
-    python3 wasm.py make --target=runtime && \
+    python3 wasm.py configure -j --target=runtime && \
+    python3 wasm.py make -j --target=runtime && \
     cd /root/${mono_version} && git clean -fdx && NOCONFIGURE=1 ./autogen.sh && \
     cd /root/${mono_version}/godot-mono-builds && \
-    python3 bcl.py make --product wasm && \
+    python3 bcl.py make -j --product wasm && \
     cd /root && \
     rm -rf /root/${mono_version}
 

--- a/build.sh
+++ b/build.sh
@@ -92,7 +92,7 @@ if [ ! -e ${mono_root} ]; then
   # Set up godot-mono-builds in tree
   git clone --progress https://github.com/godotengine/godot-mono-builds
   pushd godot-mono-builds
-  git checkout 710b275fbf29ddb03fd5285c51782951a110cdab
+  git checkout a120a65774d206e432d2971457977aa29aca9188
   export MONO_SOURCE_ROOT=${mono_root}
   python3 patch_mono.py
   popd

--- a/files/mono-build-win32.sh
+++ b/files/mono-build-win32.sh
@@ -17,7 +17,7 @@ export PATH="$(pwd)/.bin/:$PATH"
 ./autogen.sh $@ --disable-boehm --with-mcs-docs=no HOST_PROFILE=win32
 echo '#define HAVE_STRUCT_SOCKADDR_IN6 1' >> config.h
 pushd mcs/jay
-make CC=gcc
+make -j CC=gcc
 popd
 
 for dir in external/roslyn-binaries/Microsoft.Net.Compilers/[0-9]*; do


### PR DESCRIPTION
Builds are faster with 64 jobs instead of 1 :)

It's mostly relevant for 'make' but we also use the -j flag
for 'configure' as it can also trigger a build for external
dependencies (like llvm for upcoming iOS Mono builds).

--

The previous `export make="make -j"` trick was not functional.