### PR TITLE
iOS: Build Mono runtime

### DIFF
--- a/Dockerfile.ios
+++ b/Dockerfile.ios
@@ -1,5 +1,5 @@
 ARG img_version
-FROM godot-fedora:${img_version}
+FROM godot-osx:${img_version}
 
 RUN dnf -y install --setopt=install_weak_deps=False \
       automake autoconf clang gcc gcc-c++ gcc-objc gcc-objc++ cmake libicu-devel libtool libxml2-devel llvm-devel openssl-devel perl python yasm && \
@@ -20,5 +20,26 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     ln -s /root/ioscross/x86_64/bin /root/ioscross/x86_64/usr/bin
 
 ENV OSXCROSS_IOS=not_nothing
+ENV IOSCROSS_ROOT=/root/ioscross
+ENV PATH="/root/ioscross/arm64/bin:/root/ioscross/x86_64/bin:${PATH}"
+
+RUN cp -a /root/files/${mono_version} /root && \
+    cd /root/${mono_version}/godot-mono-builds && \
+    export MONO_SOURCE_ROOT=/root/${mono_version} && \
+    python3 ios.py configure -j --verbose --target=arm64 --ios-toolchain ${IOSCROSS_ROOT}/arm64 --ios-sdk ${IOSCROSS_ROOT}/arm64/SDK/iPhoneOS12.4.sdk --osx-toolchain ${OSXCROSS_ROOT} && \
+    python3 ios.py make -j --verbose --target=arm64 && \
+    python3 ios.py configure -j --target=x86_64 --ios-toolchain ${IOSCROSS_ROOT}/x86_64 --ios-sdk ${IOSCROSS_ROOT}/x86_64/SDK/iPhoneOS12.4.sdk --osx-toolchain ${OSXCROSS_ROOT} && \
+    python3 ios.py make -j --target=x86_64 && \
+    python3 bcl.py make -j --product=ios && \
+    # TODO: Emable once godot-mono-builds supports osxcross for the cross-compiler.
+    # It requires having a build of libclang with support for iOS arm64 + changes to the build scripts.
+    #python3 ios.py configure -j --target=cross-arm64 --ios-toolchain ${IOSCROSS_ROOT}/arm64 --ios-sdk ${IOSCROSS_ROOT}/arm64/SDK/iPhoneOS12.4.sdk --osx-toolchain ${OSXCROSS_ROOT} && \
+    #python3 ios.py make -j --target=cross-arm64 && \
+    cd /root && \
+    rm -rf /root/${mono_version}
+
+# Until we can build the cross-compiler, we include a pre-made build in the container.
+RUN mkdir -p /root/aot-compilers/iphone-arm64 && \
+    tar xvf /root/files/aarch64-apple-darwin-mono-sgen.tar.xz -C /root/aot-compilers/iphone-arm64
 
 CMD /bin/bash

--- a/build.sh
+++ b/build.sh
@@ -91,7 +91,7 @@ if [ ! -e ${mono_root} ]; then
   # Set up godot-mono-builds in tree
   git clone --progress https://github.com/godotengine/godot-mono-builds
   pushd godot-mono-builds
-  git checkout a120a65774d206e432d2971457977aa29aca9188
+  git checkout 562afa310ef78974b2986154220e26f58e83a72e
   export MONO_SOURCE_ROOT=${mono_root}
   python3 patch_mono.py
   popd
@@ -123,8 +123,8 @@ if [ ! -e files/MacOSX10.14.sdk.tar.xz ] || [ ! -e files/iPhoneOS12.4.sdk.tar.xz
   $podman run -it --rm -v ${files_root}/files:/root/files godot-xcode-packer:${img_version} 2>&1 | tee logs/xcode_packer.log
 fi
 
-$podman_build -t godot-ios:${img_version} -f Dockerfile.ios -v ${files_root}:/root/files . 2>&1 | tee logs/ios.log
 $podman_build_mono -t godot-osx:${img_version} -f Dockerfile.osx . 2>&1 | tee logs/osx.log
+$podman_build_mono -t godot-ios:${img_version} -f Dockerfile.ios . 2>&1 | tee logs/ios.log
 
 if [ ! -e files/msvc2017.tar ]; then
   echo


### PR DESCRIPTION
WIP build of the iOS Mono components to use in 3.2.x and master.

The separate `RUN` commands are to allow debugging intermediate stages until I'm confident that everything builds fine and as wanted.

The `PATH` and `LD_LIBRARY_PATH` changes are also local hacks that should be done directly by the godot-mono-builds scripts, since we provide `OSXCROSS_ROOT` and `--ios-toolchain` already to allow computing them.

----

Currently the last step is failing (building the cross-compiler) as the relevant godot-mono-builds script doesn't support osxcross fully yet.

One issue is that it fails detecting osxcross due to a typo, which is easily fixed:
```diff
diff --git a/ios.py b/ios.py
index 5a4e991..cec86aa 100755
--- a/ios.py
+++ b/ios.py
@@ -339,7 +339,7 @@ def setup_ios_cross_template(env: dict, opts: iOSOpts, target: str, host_arch: s
             raise RuntimeError('The \'OSXCROSS_ROOT\' environment variable is required for cross-compiling to macOS')
 
         osxcross_root = os.environ['OSXCROSS_ROOT']
-        osxcross_bin = path_join(osxcross_root, 'target', 'bin')
+        osxcross_bin = path_join(osxcross_root, host_arch, 'bin')
         osxcross_sdk = get_osxcross_sdk(osxcross_bin, arch=host_arch)
 
         env['_ios-%s_PATH' % target] = osxcross_bin
```

But then it fails as it needs `libclang` for the host platform and we don't have this in the container for now. On macOS it's available system-wide, but here we'd likely have to build it ourselves. Mono already triggers a build of llvm so maybe we can have it build clang too? Or we'd have to do a custom build separate from mono.

@neikeq might know more about what are the other roadblocks for osxcross support in that last step.