### PR TITLE
iOS and OSX: Upgrade containers to use latest osxcross and Xcode 12.0.1

### DIFF
--- a/Dockerfile.ios
+++ b/Dockerfile.ios
@@ -1,19 +1,20 @@
 ARG img_version
 FROM godot-osx:${img_version}
 
+ARG mono_version
+
 RUN dnf -y install --setopt=install_weak_deps=False \
       automake autoconf clang gcc gcc-c++ gcc-objc gcc-objc++ cmake libicu-devel libtool libxml2-devel llvm-devel openssl-devel perl python yasm && \
     git clone --progress https://github.com/tpoechtrager/cctools-port.git && \
     cd /root/cctools-port && \
-    git checkout 8239a5211bcf07d6b9d359782e1a889ec1d7cce5 && \
-    sed -i 's#./autogen.sh#libtoolize -c -i --force\n./autogen.sh#' usage_examples/ios_toolchain/build.sh && \
-    usage_examples/ios_toolchain/build.sh /root/files/iPhoneOS12.4.sdk.tar.xz arm64 && \
+    git checkout f85f5e4388047a7ab7515fcdb376b25aa11d4d1b && \
+    usage_examples/ios_toolchain/build.sh /root/files/iPhoneOS14.0.sdk.tar.xz arm64 && \
     mkdir -p /root/ioscross/arm64 && \
     mv usage_examples/ios_toolchain/target/* /root/ioscross/arm64 && \
     mkdir /root/ioscross/arm64/usr && \
     ln -s /root/ioscross/arm64/bin /root/ioscross/arm64/usr/bin && \
     sed -i 's#^TRIPLE=.*#TRIPLE="x86_64-apple-darwin11"#' usage_examples/ios_toolchain/build.sh && \
-    usage_examples/ios_toolchain/build.sh /root/files/iPhoneSimulator12.4.sdk.tar.xz x86_64 && \
+    usage_examples/ios_toolchain/build.sh /root/files/iPhoneSimulator14.0.sdk.tar.xz x86_64 && \
     mkdir -p /root/ioscross/x86_64 && \
     mv usage_examples/ios_toolchain/target/* /root/ioscross/x86_64 && \
     mkdir /root/ioscross/x86_64/usr && \
@@ -23,17 +24,22 @@ ENV OSXCROSS_IOS=not_nothing
 ENV IOSCROSS_ROOT=/root/ioscross
 ENV PATH="/root/ioscross/arm64/bin:/root/ioscross/x86_64/bin:${PATH}"
 
-RUN cp -a /root/files/${mono_version} /root && \
-    cd /root/${mono_version}/godot-mono-builds && \
+RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
+    cp -a /root/files/${mono_version} /root && \
+    cd /root/${mono_version} && \
+    patch -p1 < /root/files/patches/mono-xcode-allow-weak-import.patch && \
+    patch -p1 < /root/files/patches/mono-sys-uio-fix-preadv-misdetection.patch && \
+    cd godot-mono-builds && \
+    sed -i ios.py -e '/no_weak_imports/d' && \
     export MONO_SOURCE_ROOT=/root/${mono_version} && \
-    python3 ios.py configure -j --verbose --target=arm64 --ios-toolchain ${IOSCROSS_ROOT}/arm64 --ios-sdk ${IOSCROSS_ROOT}/arm64/SDK/iPhoneOS12.4.sdk --osx-toolchain ${OSXCROSS_ROOT} && \
+    python3 ios.py configure -j --verbose --target=arm64 --ios-toolchain ${IOSCROSS_ROOT}/arm64 --ios-sdk ${IOSCROSS_ROOT}/arm64/SDK/iPhoneOS14.0.sdk --osx-toolchain ${OSXCROSS_ROOT} && \
     python3 ios.py make -j --verbose --target=arm64 && \
-    python3 ios.py configure -j --target=x86_64 --ios-toolchain ${IOSCROSS_ROOT}/x86_64 --ios-sdk ${IOSCROSS_ROOT}/x86_64/SDK/iPhoneOS12.4.sdk --osx-toolchain ${OSXCROSS_ROOT} && \
+    python3 ios.py configure -j --target=x86_64 --ios-toolchain ${IOSCROSS_ROOT}/x86_64 --ios-sdk ${IOSCROSS_ROOT}/x86_64/SDK/iPhoneOS14.0.sdk --osx-toolchain ${OSXCROSS_ROOT} && \
     python3 ios.py make -j --target=x86_64 && \
     python3 bcl.py make -j --product=ios && \
     # TODO: Emable once godot-mono-builds supports osxcross for the cross-compiler.
     # It requires having a build of libclang with support for iOS arm64 + changes to the build scripts.
-    #python3 ios.py configure -j --target=cross-arm64 --ios-toolchain ${IOSCROSS_ROOT}/arm64 --ios-sdk ${IOSCROSS_ROOT}/arm64/SDK/iPhoneOS12.4.sdk --osx-toolchain ${OSXCROSS_ROOT} && \
+    #python3 ios.py configure -j --target=cross-arm64 --ios-toolchain ${IOSCROSS_ROOT}/arm64 --ios-sdk ${IOSCROSS_ROOT}/arm64/SDK/iPhoneOS14.0.sdk --osx-toolchain ${OSXCROSS_ROOT} && \
     #python3 ios.py make -j --target=cross-arm64 && \
     cd /root && \
     rm -rf /root/${mono_version}

--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -8,8 +8,8 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
       automake autoconf bzip2-devel clang libicu-devel libtool libxml2-devel llvm-devel openssl-devel yasm && \
     git clone --progress https://github.com/tpoechtrager/osxcross.git && \
     cd /root/osxcross && \
-    git checkout 542acc2ef6c21aeb3f109c03748b1015a71fed63 && \
-    ln -s /root/files/MacOSX10.14.sdk.tar.xz /root/osxcross/tarballs && \
+    git checkout 45d2f7ec2ee68c9ad51d590869609b5b3b028605 && \
+    ln -s /root/files/MacOSX10.15.sdk.tar.xz /root/osxcross/tarballs && \
     UNATTENDED=1 ./build.sh
 
 ENV OSXCROSS_ROOT=/root/osxcross
@@ -17,11 +17,13 @@ ENV PATH="/root/osxcross/target/bin:${PATH}"
 
 RUN cp -a /root/files/${mono_version} /root && \
     cd /root/${mono_version} && \
-    export CMAKE=/root/osxcross/target/bin/x86_64-apple-darwin18-cmake && \
+    patch -p1 < /root/files/patches/mono-xcode-allow-weak-import.patch && \
+    patch -p1 < /root/files/patches/mono-sys-uio-fix-preadv-misdetection.patch && \
+    export CMAKE=/root/osxcross/target/bin/x86_64-apple-darwin19-cmake && \
     NOCONFIGURE=1 ./autogen.sh && \
     ./configure --prefix=/root/dependencies/mono \
         --build=x86_64-linux-gnu \
-        --host=x86_64-apple-darwin18 \
+        --host=x86_64-apple-darwin19 \
         --disable-boehm \
         --disable-mcs-build \
         --with-tls=pthread \

--- a/Dockerfile.xcode
+++ b/Dockerfile.xcode
@@ -1,3 +1,4 @@
+ARG img_version
 FROM godot-fedora:${img_version}
 
 RUN dnf -y install --setopt=install_weak_deps=False \
@@ -15,28 +16,31 @@ RUN dnf -y install --setopt=install_weak_deps=False \
 
 CMD mkdir -p /root/xcode && \
     cd /root/xcode && \
-    xar -xf /root/files/Xcode_10.3.xip && \
+    xar -xf /root/files/Xcode_12.0.1.xip && \
     /root/pbzx/pbzx -n Content | cpio -i && \
-    cp -r Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk /tmp/MacOSX10.14.sdk && \
-    mkdir -p /tmp/MacOSX10.14.sdk/usr/include/c++ && \
-    cp -r Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1 /tmp/MacOSX10.14.sdk/usr/include/c++/ && \
-    mkdir -p mkdir -p /tmp/MacOSX10.14.sdk/usr/share/man && \
+    export OSX_SDK=MacOSX10.15.sdk && \
+    cp -r Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk /tmp/${OSX_SDK} && \
+    mkdir -p /tmp/${OSX_SDK}/usr/include/c++ && \
+    cp -r Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1 /tmp/${OSX_SDK}/usr/include/c++/ && \
+    mkdir -p mkdir -p /tmp/${OSX_SDK}/usr/share/man && \
     cp -rf Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/share/man/man1 \
            Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/share/man/man3 \
-           Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/share/man/man5 /tmp/MacOSX10.14.sdk/usr/share/man/ && \
+           Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/share/man/man5 /tmp/${OSX_SDK}/usr/share/man/ && \
     cd /tmp && \
-    tar -cJf /root/files/MacOSX10.14.sdk.tar.xz MacOSX10.14.sdk && \
-    rm -rf MacOSX10.14 && \
+    tar -cJf /root/files/${OSX_SDK}.tar.xz ${OSX_SDK} && \
+    rm -rf ${OSX_SDK} && \
     cd /root/xcode && \
-    cp -r Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk /tmp/iPhoneOS12.4.sdk && \
-    mkdir -p /tmp/iPhoneOS12.4.sdk/usr/include/c++ && \
-    cp -r Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1 /tmp/iPhoneOS12.4.sdk/usr/include/c++/ && \
+    export IOS_SDK=iPhoneOS14.0.sdk && \
+    cp -r Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk /tmp/${IOS_SDK} && \
+    mkdir -p /tmp/${IOS_SDK}/usr/include/c++ && \
+    cp -r Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1 /tmp/${IOS_SDK}/usr/include/c++/ && \
     cd /tmp && \
-    tar -cJf /root/files/iPhoneOS12.4.sdk.tar.xz iPhoneOS12.4.sdk && \
-    rm -rf iPhoneOS12.4.sdk && \
+    tar -cJf /root/files/${IOS_SDK}.tar.xz ${IOS_SDK} && \
+    rm -rf ${IOS_SDK} && \
     cd /root/xcode && \
-    cp -r Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk /tmp/iPhoneOS12.4.sdk && \
-    mkdir -p /tmp/iPhoneOS12.4.sdk/usr/include/c++ && \
-    cp -r Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1 /tmp/iPhoneOS12.4.sdk/usr/include/c++/ && \
+    cp -r Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk /tmp/${IOS_SDK} && \
+    mkdir -p /tmp/${IOS_SDK}/usr/include/c++ && \
+    cp -r Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1 /tmp/${IOS_SDK}/usr/include/c++/ && \
     cd /tmp && \
-    tar -cJf /root/files/iPhoneSimulator12.4.sdk.tar.xz iPhoneOS12.4.sdk
+    tar -cJf /root/files/iPhoneSimulator14.0.sdk.tar.xz ${IOS_SDK} && \
+    rm -rf ${IOS_SDK}

--- a/build.sh
+++ b/build.sh
@@ -109,9 +109,9 @@ $podman_build_mono -t godot-ubuntu-32:${img_version} -f Dockerfile.ubuntu-32 . 2
 $podman_build_mono -t godot-javascript:${img_version} -f Dockerfile.javascript . 2>&1 | tee logs/javascript.log
 $podman_build_mono -t godot-android:${img_version} -f Dockerfile.android . 2>&1 | tee logs/android.log
 
-if [ ! -e files/MacOSX10.14.sdk.tar.xz ] || [ ! -e files/iPhoneOS12.4.sdk.tar.xz ] || [ ! -e files/iPhoneSimulator12.4.sdk.tar.xz ]; then
-  if [ ! -e files/Xcode_10.3.xip ]; then
-    echo "files/Xcode_10.3.xip is required. It can be downloaded from https://developer.apple.com/download/more/ with a valid apple ID"
+if [ ! -e files/MacOSX10.15.sdk.tar.xz ] || [ ! -e files/iPhoneOS14.0.sdk.tar.xz ] || [ ! -e files/iPhoneSimulator14.0.sdk.tar.xz ]; then
+  if [ ! -e files/Xcode_12.0.1.xip ]; then
+    echo "files/Xcode_12.0.1.xip is required. It can be downloaded from https://developer.apple.com/download/more/ with a valid apple ID"
     exit 1
   fi
 

--- a/files/patches/mono-sys-uio-fix-preadv-misdetection.patch
+++ b/files/patches/mono-sys-uio-fix-preadv-misdetection.patch
@@ -1,0 +1,38 @@
+Backported from Unity's mono fork:
+https://github.com/Unity-Technologies/mono/pull/1309
+---
+
+diff --git a/support/sys-uio.c b/support/sys-uio.c
+index 53e162f9..5e44f796 100644
+--- a/support/sys-uio.c
++++ b/support/sys-uio.c
+@@ -82,7 +82,7 @@ Mono_Posix_Syscall_writev (int dirfd, struct Mono_Posix_Iovec *iov, gint32 iovcn
+ }
+ #endif /* def HAVE_WRITEV */
+ 
+-#ifdef HAVE_PREADV
++#if defined(HAVE_PREADV) && !defined(__APPLE__) // Configure incorrectly detects that this function is available on macOS SDK 11.0 (it is not)
+ gint64
+ Mono_Posix_Syscall_preadv (int dirfd, struct Mono_Posix_Iovec *iov, gint32 iovcnt, gint64 off)
+ {
+@@ -100,9 +100,9 @@ Mono_Posix_Syscall_preadv (int dirfd, struct Mono_Posix_Iovec *iov, gint32 iovcn
+ 	free (v);
+ 	return res;
+ }
+-#endif /* def HAVE_PREADV */
++#endif /* defined(HAVE_PREADV) && !defined(__APPLE__) */
+ 
+-#ifdef HAVE_PWRITEV
++#if defined(HAVE_PWRITEV) && !defined(__APPLE__) // Configure incorrectly detects that this function is available on macOS SDK 11.0 (it is not)
+ gint64
+ Mono_Posix_Syscall_pwritev (int dirfd, struct Mono_Posix_Iovec *iov, gint32 iovcnt, gint64 off)
+ {
+@@ -120,7 +120,7 @@ Mono_Posix_Syscall_pwritev (int dirfd, struct Mono_Posix_Iovec *iov, gint32 iovc
+ 	free (v);
+ 	return res;
+ }
+-#endif /* def HAVE_PWRITEV */
++#endif /* defined(HAVE_PWRITEV) && !defined(__APPLE__) */
+ 
+ 
+ /*

--- a/files/patches/mono-xcode-allow-weak-import.patch
+++ b/files/patches/mono-xcode-allow-weak-import.patch
@@ -1,0 +1,29 @@
+Workaround for Xcode bug: https://github.com/mono/mono/issues/19393
+---
+
+diff --git a/sdks/builds/ios.mk b/sdks/builds/ios.mk
+index 0470ccb57cb..bf1036330c5 100644
+--- a/sdks/builds/ios.mk
++++ b/sdks/builds/ios.mk
+@@ -90,7 +90,6 @@ _ios-$(1)_CPPFLAGS= \
+ 	-DSMALL_CONFIG -D_XOPEN_SOURCE -DHOST_IOS -DHAVE_LARGE_FILE_SUPPORT=1 \
+ 
+ _ios-$(1)_LDFLAGS= \
+-	-Wl,-no_weak_imports \
+ 	-arch $(3) \
+ 	-framework CoreFoundation \
+ 	-lobjc -lc++
+diff --git a/sdks/builds/mac.mk b/sdks/builds/mac.mk
+index bded6b2c22b..98d8be2f456 100644
+--- a/sdks/builds/mac.mk
++++ b/sdks/builds/mac.mk
+@@ -36,8 +36,7 @@ _mac-$(1)_CXXFLAGS= \
+ 
+ _mac-$(1)_CPPFLAGS=
+ 
+-_mac-$(1)_LDFLAGS= \
+-	-Wl,-no_weak_imports
++_mac-$(1)_LDFLAGS=
+ 
+ _mac-$(1)_CONFIGURE_FLAGS= \
+ 	--disable-boehm \


### PR DESCRIPTION
Provides SDKs for iOS 14.0 and macOS 10.15.

Mono is patched to fix a regression in Xcode 11.4+, still unfixed by Apple.

Fixes missing arguments in Xcode and iOS dockerfiles, seems like some changes
were not properly committed during the last refactor.

----

WIP as I'm still running into issues building Mono for iOS:
```
/root/mono-6.6.0.166/support/sys-uio.c:99:8: error: implicit declaration of function 'preadv' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        res = preadv (dirfd, v, iovcnt, (off_t) off);
              ^
/root/mono-6.6.0.166/support/sys-uio.c:119:8: error: implicit declaration of function 'pwritev' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        res = pwritev (dirfd, v, iovcnt, (off_t) off);
              ^
2 errors generated.
```