### PR TITLE
Android: Fix 32-bit Mono builds compat with API < 21

### DIFF
--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -11,7 +11,7 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
     unzip commandlinetools-linux-6609375_latest.zip && \
     rm commandlinetools-linux-6609375_latest.zip && \
     yes | tools/bin/sdkmanager --licenses && \
-    tools/bin/sdkmanager 'ndk;21.3.6528147' 'build-tools;29.0.3' 'platforms;android-29' 'cmake;3.10.2.4988404'
+    tools/bin/sdkmanager 'ndk;21.3.6528147' 'build-tools;30.0.1' 'platforms;android-30' 'cmake;3.10.2.4988404'
 
 ENV ANDROID_SDK_ROOT=/root/sdk/
 ENV ANDROID_NDK_ROOT=/root/sdk/ndk/21.3.6528147/

--- a/build.sh
+++ b/build.sh
@@ -88,7 +88,7 @@ if [ ! -e ${mono_root} ]; then
   # Set up godot-mono-builds in tree
   git clone --progress https://github.com/godotengine/godot-mono-builds
   pushd godot-mono-builds
-  git checkout 42b90fe9a6a6ad6756a62866dc0dcc04a694f83b
+  git checkout 61e36a93b6264248b2081136ff35dc544f06563b
   export MONO_SOURCE_ROOT=${mono_root}
   python3 patch_mono.py
   popd


### PR DESCRIPTION
The fix is done in https://github.com/godotengine/godot-mono-builds/pull/22.

Also bump build-tools/platform to API 30 to match current 3.2 branch.