### PR TITLE
Android: Update env variables and NDK preinstallation to match Godot buildsystem changes

### DIFF
--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -11,10 +11,9 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
     unzip commandlinetools-linux-6609375_latest.zip && \
     rm commandlinetools-linux-6609375_latest.zip && \
     yes | tools/bin/sdkmanager --licenses && \
-    tools/bin/sdkmanager 'ndk;21.3.6528147' 'build-tools;30.0.1' 'platforms;android-30' 'cmake;3.10.2.4988404'
+    tools/bin/sdkmanager 'cmdline-tools;latest' 'build-tools;30.0.1' 'platforms;android-30' 'cmake;3.10.2.4988404'
 
 ENV ANDROID_SDK_ROOT=/root/sdk/
-ENV ANDROID_NDK_ROOT=/root/sdk/ndk/21.3.6528147/
 
 RUN cp -a /root/files/${mono_version} /root && \
     export MONO_SOURCE_ROOT=/root/${mono_version} && \

--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -3,6 +3,9 @@ FROM godot-mono:${img_version}
 
 ARG mono_version
 
+ENV ANDROID_NDK_VERSION=21.3.6528147
+ENV ANDROID_SDK_ROOT=/root/sdk/
+
 RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
     dnf -y install --setopt=install_weak_deps=False \
       java-1.8.0-openjdk-devel ncurses-compat-libs && \
@@ -11,9 +14,9 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
     unzip commandlinetools-linux-6609375_latest.zip && \
     rm commandlinetools-linux-6609375_latest.zip && \
     yes | tools/bin/sdkmanager --licenses && \
-    tools/bin/sdkmanager 'cmdline-tools;latest' 'build-tools;30.0.1' 'platforms;android-30' 'cmake;3.10.2.4988404'
+    tools/bin/sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" 'ndk;${ANDROID_NDK_VERSION}' 'cmdline-tools;latest' 'build-tools;30.0.1' 'platforms;android-30' 'cmake;3.10.2.4988404'
 
-ENV ANDROID_SDK_ROOT=/root/sdk/
+ENV ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk/${ANDROID_NDK_VERSION}
 
 RUN cp -a /root/files/${mono_version} /root && \
     export MONO_SOURCE_ROOT=/root/${mono_version} && \

--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -3,8 +3,9 @@ FROM godot-mono:${img_version}
 
 ARG mono_version
 
+ENV ANDROID_SDK_ROOT=/root/sdk
 ENV ANDROID_NDK_VERSION=21.3.6528147
-ENV ANDROID_SDK_ROOT=/root/sdk/
+ENV ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk/${ANDROID_NDK_VERSION}
 
 RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
     dnf -y install --setopt=install_weak_deps=False \
@@ -15,8 +16,6 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
     rm commandlinetools-linux-6609375_latest.zip && \
     yes | tools/bin/sdkmanager --licenses && \
     tools/bin/sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" 'ndk;${ANDROID_NDK_VERSION}' 'cmdline-tools;latest' 'build-tools;30.0.1' 'platforms;android-30' 'cmake;3.10.2.4988404'
-
-ENV ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk/${ANDROID_NDK_VERSION}
 
 RUN cp -a /root/files/${mono_version} /root && \
     export MONO_SOURCE_ROOT=/root/${mono_version} && \


### PR DESCRIPTION
Update configuration based on the Android buildsystem change in https://github.com/godotengine/godot/pull/44949.