### PR TITLE
Update images to Fedora 33, Mono 6.12.0.122, Xcode 12.4, Emscripten 2.0.15

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,10 +1,10 @@
-FROM fedora:32
+FROM fedora:33
 
 WORKDIR /root
 
 RUN dnf -y upgrade --setopt=install_weak_deps=False && \
     dnf -y install --setopt=install_weak_deps=False \
       bash bzip2 curl git make nano patch pkgconfig python-unversioned-command python3-pip unzip which xz && \
-    pip install scons==4.0.1
+    pip install scons==4.1.0
 
 CMD /bin/bash

--- a/Dockerfile.ios
+++ b/Dockerfile.ios
@@ -45,7 +45,7 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
 
 # Until we can build the cross-compiler, we include a pre-made build in the container.
 RUN mkdir -p /root/aot-compilers/iphone-arm64 && \
-    curl -LO https://github.com/godotengine/godot-mono-builds/releases/download/release-bda87f2/ios-cross-arm64.zip && \
+    curl -LO https://github.com/godotengine/godot-mono-builds/releases/download/release-df330ce/ios-cross-arm64.zip && \
     dnf -y install --setopt=install_weak_deps=False p7zip && \
     7za e ios-cross-arm64.zip ios-cross-arm64-release/bin/aarch64-apple-darwin-mono-sgen -o/root/aot-compilers/iphone-arm64 && \
     rm ios-cross-arm64.zip

--- a/Dockerfile.ios
+++ b/Dockerfile.ios
@@ -3,13 +3,13 @@ FROM godot-osx:${img_version}
 
 ARG mono_version
 
-ENV IOS_SDK=14.2
+ENV IOS_SDK=14.4
 
 RUN dnf -y install --setopt=install_weak_deps=False \
       automake autoconf clang gcc gcc-c++ gcc-objc gcc-objc++ cmake libicu-devel libtool libxml2-devel llvm-devel openssl-devel perl python yasm && \
     git clone --progress https://github.com/tpoechtrager/cctools-port.git && \
     cd /root/cctools-port && \
-    git checkout 634a084377ee2e2932c66459b0396edf76da2e9f && \
+    git checkout 14ab64360c556c1263e022318ee4be1077d7a839 && \
     usage_examples/ios_toolchain/build.sh /root/files/iPhoneOS${IOS_SDK}.sdk.tar.xz arm64 && \
     mkdir -p /root/ioscross/arm64 && \
     mv usage_examples/ios_toolchain/target/* /root/ioscross/arm64 && \

--- a/Dockerfile.javascript
+++ b/Dockerfile.javascript
@@ -3,7 +3,7 @@ FROM godot-mono:${img_version}
 
 ARG mono_version
 
-ENV EMSDK_CLASSICAL=2.0.11
+ENV EMSDK_CLASSICAL=2.0.15
 ENV EMSDK_MONO=1.39.9
 
 RUN if [ -z "${mono_version}" ]; then printf "\n\nArgument mono_version is mandatory!\n\n"; exit 1; fi && \

--- a/Dockerfile.mono
+++ b/Dockerfile.mono
@@ -17,8 +17,8 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
     rm -rf /root/${mono_version} && \
     cert-sync /etc/pki/tls/certs/ca-bundle.crt && \
     rpm -ivh --nodeps \
-      https://download.mono-project.com/repo/centos8-stable/m/msbuild/msbuild-16.6+xamarinxplat.2020.04.29.14.43-0.xamarin.6.epel8.noarch.rpm \
-      https://download.mono-project.com/repo/centos8-stable/m/msbuild/msbuild-sdkresolver-16.6+xamarinxplat.2020.04.29.14.43-0.xamarin.6.epel8.noarch.rpm \
+      https://download.mono-project.com/repo/centos8-stable/m/msbuild/msbuild-16.6+xamarinxplat.2021.01.15.16.11-0.xamarin.2.epel8.noarch.rpm \
+      https://download.mono-project.com/repo/centos8-stable/m/msbuild/msbuild-sdkresolver-16.6+xamarinxplat.2021.01.15.16.11-0.xamarin.2.epel8.noarch.rpm \
       https://download.mono-project.com/repo/centos8-stable/m/msbuild-libhostfxr/msbuild-libhostfxr-3.0.0.2019.04.16.02.13-0.xamarin.4.epel8.x86_64.rpm \
       https://download.mono-project.com/repo/centos8-stable/n/nuget/nuget-5.6.0.6489.bin-0.xamarin.1.epel8.noarch.rpm
 

--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -8,8 +8,8 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
       automake autoconf bzip2-devel clang libicu-devel libtool libxml2-devel llvm-devel openssl-devel yasm && \
     git clone --progress https://github.com/tpoechtrager/osxcross.git && \
     cd /root/osxcross && \
-    git checkout 9d7f6c2461dccb2b2781fff323f231a4b096fe41 && \
-    ln -s /root/files/MacOSX11.0.sdk.tar.xz /root/osxcross/tarballs && \
+    git checkout 61925a29c404fc547ce9d51eb2ee4a09bd6533da && \
+    ln -s /root/files/MacOSX11.1.sdk.tar.xz /root/osxcross/tarballs && \
     UNATTENDED=1 ./build.sh
 
 ENV OSXCROSS_ROOT=/root/osxcross
@@ -17,11 +17,11 @@ ENV PATH="/root/osxcross/target/bin:${PATH}"
 
 RUN cp -a /root/files/${mono_version} /root && \
     cd /root/${mono_version} && \
-    export CMAKE=/root/osxcross/target/bin/x86_64-apple-darwin20-cmake && \
+    export CMAKE=/root/osxcross/target/bin/x86_64-apple-darwin20.2-cmake && \
     NOCONFIGURE=1 ./autogen.sh && \
     ./configure --prefix=/root/dependencies/mono \
         --build=x86_64-linux-gnu \
-        --host=x86_64-apple-darwin20 \
+        --host=x86_64-apple-darwin20.2 \
         --disable-boehm \
         --disable-mcs-build \
         --with-tls=pthread \

--- a/Dockerfile.ubuntu-32
+++ b/Dockerfile.ubuntu-32
@@ -29,10 +29,10 @@ RUN cp -a /root/files/${mono_version} /root && \
     cd /root && \
     rm -rf /root/${mono_version} && \
     cert-sync /etc/ssl/certs/ca-certificates.crt && \
-    wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild_16.6+xamarinxplat.2020.04.29.14.43-0xamarin5+ubuntu1604b1_all.deb && \
+    wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild_16.6+xamarinxplat.2021.01.15.16.11-0xamarin1+ubuntu1604b1_all.deb && \
+    wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild-sdkresolver_16.6+xamarinxplat.2021.01.15.16.11-0xamarin1+ubuntu1604b1_all.deb && \
     wget https://download.mono-project.com/repo/ubuntu/pool/main/c/core-setup/msbuild-libhostfxr_3.0.0.2019.04.16.02.13-0xamarin4+ubuntu1604b1_i386.deb && \
-    wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild-sdkresolver_16.6+xamarinxplat.2020.04.29.14.43-0xamarin5+ubuntu1604b1_all.deb && \
-    wget https://download.mono-project.com/repo/ubuntu/pool/main/n/nuget/nuget_5.5.0.6382.bin-0xamarin1+ubuntu1604b1_all.deb && \
+    wget https://download.mono-project.com/repo/ubuntu/pool/main/n/nuget/nuget_5.6.0.6489.bin-0xamarin1+ubuntu1604b1_all.deb && \
     dpkg -i --force-all *.deb && \
     sed -i '/Depends.*mono/d' /var/lib/dpkg/status && \
     ln -s /usr/bin/mono /usr/bin/cli && \

--- a/Dockerfile.ubuntu-64
+++ b/Dockerfile.ubuntu-64
@@ -29,10 +29,10 @@ RUN cp -a /root/files/${mono_version} /root && \
     cd /root && \
     rm -rf /root/${mono_version} && \
     cert-sync /etc/ssl/certs/ca-certificates.crt && \
-    wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild_16.6+xamarinxplat.2020.04.29.14.43-0xamarin5+ubuntu1604b1_all.deb && \
+    wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild_16.6+xamarinxplat.2021.01.15.16.11-0xamarin1+ubuntu1604b1_all.deb && \
+    wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild-sdkresolver_16.6+xamarinxplat.2021.01.15.16.11-0xamarin1+ubuntu1604b1_all.deb && \
     wget https://download.mono-project.com/repo/ubuntu/pool/main/c/core-setup/msbuild-libhostfxr_3.0.0.2019.04.16.02.13-0xamarin4+ubuntu1604b1_amd64.deb && \
-    wget https://download.mono-project.com/repo/ubuntu/pool/main/m/msbuild/msbuild-sdkresolver_16.6+xamarinxplat.2020.04.29.14.43-0xamarin5+ubuntu1604b1_all.deb && \
-    wget https://download.mono-project.com/repo/ubuntu/pool/main/n/nuget/nuget_5.5.0.6382.bin-0xamarin1+ubuntu1604b1_all.deb && \
+    wget https://download.mono-project.com/repo/ubuntu/pool/main/n/nuget/nuget_5.6.0.6489.bin-0xamarin1+ubuntu1604b1_all.deb && \
     dpkg -i --force-all *.deb && \
     sed -i '/Depends.*mono/d' /var/lib/dpkg/status && \
     ln -s /usr/bin/mono /usr/bin/cli && \

--- a/Dockerfile.xcode
+++ b/Dockerfile.xcode
@@ -16,9 +16,9 @@ RUN dnf -y install --setopt=install_weak_deps=False \
 
 CMD mkdir -p /root/xcode && \
     cd /root/xcode && \
-    xar -xf /root/files/Xcode_12.2.xip && \
+    xar -xf /root/files/Xcode_12.4.xip && \
     /root/pbzx/pbzx -n Content | cpio -i && \
-    export OSX_SDK=MacOSX11.0.sdk && \
+    export OSX_SDK=MacOSX11.1.sdk && \
     cp -r Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk /tmp/${OSX_SDK} && \
     mkdir -p /tmp/${OSX_SDK}/usr/include/c++ && \
     cp -r Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1 /tmp/${OSX_SDK}/usr/include/c++/ && \
@@ -30,8 +30,8 @@ CMD mkdir -p /root/xcode && \
     tar -cJf /root/files/${OSX_SDK}.tar.xz ${OSX_SDK} && \
     rm -rf ${OSX_SDK} && \
     cd /root/xcode && \
-    export IOS_SDK=iPhoneOS14.2.sdk && \
-    export IOS_SIMULATOR_SDK=iPhoneSimulator14.2.sdk && \
+    export IOS_SDK=iPhoneOS14.4.sdk && \
+    export IOS_SIMULATOR_SDK=iPhoneSimulator14.4.sdk && \
     cp -r Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk /tmp/${IOS_SDK} && \
     mkdir -p /tmp/${IOS_SDK}/usr/include/c++ && \
     cp -r Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1 /tmp/${IOS_SDK}/usr/include/c++/ && \

--- a/README.md
+++ b/README.md
@@ -35,18 +35,18 @@ The 'build.sh' script included is used to build the containers themselves.
 
 Run the command using:
 
-    ./build.sh 3.2 mono-6.12.0.114
+    ./build.sh 3.x mono-6.12.0.122
 
 Note that this will also download that Mono branch (2020-02) from Mono repository.
-That branch corresponds to the given Mono version (6.12.0.114) as per
+That branch corresponds to the given Mono version (6.12.0.122) as per
 https://www.mono-project.com/docs/about-mono/versioning/#mono-source-versioning .
 
 More details can be found in the Godot https://github.com/godotengine/godot-mono-builds
 repository (but you don't need this repository, as in this case Mono is built
 inside the containers)
 
-The above will generate images using the tag '3.2-mono-6.12.0.114'. This is convenient
-since as of today, this branch can be used to compile every 3.2.x version or
+The above will generate images using the tag '3.x-mono-6.12.0.122'. This is convenient
+since as of today, this branch can be used to compile every 3.x version or
 your custom modifications.
 
 ### Selecting which images to build
@@ -138,4 +138,3 @@ These are the expected container image sizes, so you can plan your disk usage in
 
 In addition to this, generating containers will also require some host disk space (around 4.5GB)
 for the downloaded Mono sources and dependencies.
-

--- a/build.sh
+++ b/build.sh
@@ -120,9 +120,9 @@ $podman_build_mono -t godot-ubuntu-32:${img_version} -f Dockerfile.ubuntu-32 . 2
 $podman_build_mono -t godot-javascript:${img_version} -f Dockerfile.javascript . 2>&1 | tee logs/javascript.log
 $podman_build_mono -t godot-android:${img_version} -f Dockerfile.android . 2>&1 | tee logs/android.log
 
-XCODE_SDK=12.2
-OSX_SDK=11.0
-IOS_SDK=14.2
+XCODE_SDK=12.4
+OSX_SDK=11.1
+IOS_SDK=14.4
 if [ ! -e files/MacOSX${OSX_SDK}.sdk.tar.xz ] || [ ! -e files/iPhoneOS${IOS_SDK}.sdk.tar.xz ] || [ ! -e files/iPhoneSimulator${IOS_SDK}.sdk.tar.xz ]; then
   if [ ! -e files/Xcode_${XCODE_SDK}.xip ]; then
     echo "files/Xcode_${XCODE_SDK}.xip is required. It can be downloaded from https://developer.apple.com/download/more/ with a valid apple ID."

--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,7 @@ fi
 if [ -z "$1" -o -z "$2" ]; then
   echo "Usage: $0 <godot branch> <mono version> [<mono branch> <mono commit hash>]"
   echo
-  echo "Examples: $0 3.2 mono-6.12.0.114"
+  echo "Examples: $0 3.x mono-6.12.0.122"
   echo "	$0 master mono-6.6.0.160 2019-08 bef1e6335812d32f8eab648c0228fc624b9f8357"
   echo
   echo "godot branch:"
@@ -97,7 +97,7 @@ if [ ! -e ${mono_root} ]; then
   # Set up godot-mono-builds in tree
   git clone --progress https://github.com/godotengine/godot-mono-builds
   pushd godot-mono-builds
-  git checkout d462909236457cd212b17378c29ce336749e260d
+  git checkout df330ce0bec35836a33b97db27c1e72014571103
   export MONO_SOURCE_ROOT=${mono_root}
   python3 patch_mono.py
   popd

--- a/upload.sh
+++ b/upload.sh
@@ -7,21 +7,27 @@ if ! which $podman; then
   podman=docker
 fi
 
-registry=$1
+img_version=$1
+registry=$2
+
+if [ -z "${img_version}" ]; then
+  echo "No image version was provided, aborting. Check script for usage."
+  exit 1
+fi
 
 if [ -z "${registry}" ]; then
   registry=registry.prehensile-tales.com
 fi
 
-$podman push godot-export:latest ${registry}/godot/export
-$podman push godot-mono-glue:latest ${registry}/godot/mono-glue
-$podman push godot-windows:latest ${registry}/godot/windows
-$podman push godot-ubuntu-32:latest ${registry}/godot/ubuntu-32
-$podman push godot-ubuntu-64:latest ${registry}/godot/ubuntu-64
-$podman push godot-javascript:latest ${registry}/godot/javascript
-$podman push godot-xcode-packer:latest ${registry}/godot/xcode-packer
+$podman push godot-export:${img_version} ${registry}/godot/export
+$podman push godot-mono-glue:${img_version} ${registry}/godot/mono-glue
+$podman push godot-windows:${img_version} ${registry}/godot/windows
+$podman push godot-ubuntu-32:${img_version} ${registry}/godot/ubuntu-32
+$podman push godot-ubuntu-64:${img_version} ${registry}/godot/ubuntu-64
+$podman push godot-javascript:${img_version} ${registry}/godot/javascript
+$podman push godot-xcode-packer:${img_version} ${registry}/godot/xcode-packer
 
-$podman push godot-android:latest ${registry}/godot-private/android
-$podman push godot-ios:latest ${registry}/godot-private/ios
-$podman push godot-osx:latest ${registry}/godot-private/macosx
-$podman push godot-msvc:latest ${registry}/godot-private/uwp
+$podman push godot-android:${img_version} ${registry}/godot-private/android
+$podman push godot-ios:${img_version} ${registry}/godot-private/ios
+$podman push godot-osx:${img_version} ${registry}/godot-private/macosx
+$podman push godot-msvc:${img_version} ${registry}/godot-private/uwp


### PR DESCRIPTION
FYI @Faless @neikeq @bruvzg @naithar 

That's what I plan to use for 3.3 RC7 / stable.

Tested to make a local `3.x-mono-6.12.0.122` build, will upload it to @hpvb's registry soon.

I also made a successful build of Godot from the `3.x` branch for all platforms, standard + Mono.