### PR TITLE
Linux 32-bit x86: Update container to Ubuntu 16.04, keep GCC 5

### DIFF
--- a/Dockerfile.ubuntu-32
+++ b/Dockerfile.ubuntu-32
@@ -1,24 +1,13 @@
-FROM i386/ubuntu:trusty
+FROM i386/ubuntu:xenial
 
 ARG mono_version
 
 RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
-    apt-get update && \
-    apt-get -y install wget && \
-    cd /root && \
-    wget -O- 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F' | apt-key add - && \
-    wget -O- 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x8E51A6D660CD88D67D65221D90BD7EACED8E640A' | apt-key add - && \
-    echo 'deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu trusty main' >> /etc/apt/sources.list && \
-    echo 'deb http://ppa.launchpad.net/mc3man/trusty-media/ubuntu trusty main' >> /etc/apt/sources.list && \
     apt-get -y update && \
     apt-get -y install --no-install-recommends \
-      autoconf automake bzip2 cmake curl gettext git libtool make perl scons xz-utils \
-      gcc-9 g++-9 libudev-dev libx11-dev libxcursor-dev libxrandr-dev libasound2-dev libpulse-dev \
-      libgl1-mesa-dev libglu1-mesa-dev libxi-dev libxinerama-dev yasm && \
-    ln -sf /usr/bin/gcc-ranlib-9 /usr/bin/gcc-ranlib && \
-    ln -sf /usr/bin/gcc-ar-9 /usr/bin/gcc-ar && \
-    ln -sf /usr/bin/gcc-9 /usr/bin/gcc && \
-    ln -sf /usr/bin/g++-9 /usr/bin/g++
+      autoconf automake bzip2 ca-certificates cmake curl gettext git libtool make perl python3 scons wget xz-utils \
+      gcc g++ libudev-dev libx11-dev libxcursor-dev libxrandr-dev libasound2-dev libpulse-dev \
+      libgl1-mesa-dev libglu1-mesa-dev libxi-dev libxinerama-dev yasm
 
 RUN cp -a /root/files/${mono_version} /root && \
     cd /root/${mono_version} && \


### PR DESCRIPTION
We've had troubles trying to upgrade GCC on Ubuntu 14.04 i386 containers
as statically linking libstdc++ would then trigger crashes when running
those binaries on more recent Ubuntu versions (which seems to be a Ubuntu
bug, other distros don't have the problem).

Upgrading to Ubuntu 16.04 and using its default GCC 5 version seems to
produce working binaries even with statically linked libstdc++, and that
should still be good enough for the few 32-bit Linux users we have.

Ref. https://github.com/godotengine/godot/issues/31743