### PR TITLE
iOS: Disable non-working arm64 simulator build

### DIFF
--- a/Dockerfile.ios
+++ b/Dockerfile.ios
@@ -10,17 +10,22 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     git clone --progress https://github.com/tpoechtrager/cctools-port.git && \
     cd /root/cctools-port && \
     git checkout 14ab64360c556c1263e022318ee4be1077d7a839 && \
+    # arm64 device
     usage_examples/ios_toolchain/build.sh /root/files/iPhoneOS${IOS_SDK}.sdk.tar.xz arm64 && \
     mkdir -p /root/ioscross/arm64 && \
     mv usage_examples/ios_toolchain/target/* /root/ioscross/arm64 && \
     mkdir /root/ioscross/arm64/usr && \
     ln -s /root/ioscross/arm64/bin /root/ioscross/arm64/usr/bin && \
-    sed -i 's/miphoneos-version-min/mios-simulator-version-min/g' usage_examples/ios_toolchain/wrapper.c && \
-    usage_examples/ios_toolchain/build.sh /root/files/iPhoneSimulator${IOS_SDK}.sdk.tar.xz arm64 && \
-    mkdir -p /root/ioscross/arm64_sim && \
-    mv usage_examples/ios_toolchain/target/* /root/ioscross/arm64_sim && \
-    mkdir /root/ioscross/arm64_sim/usr && \
-    ln -s /root/ioscross/arm64_sim/bin /root/ioscross/arm64_sim/usr/bin && \
+    # arm64 simulator
+    # Disabled for now as it doesn't work with cctools-port and current LLVM:
+    # Cf. https://github.com/tpoechtrager/cctools-port/issues/102
+    #sed -i 's/miphoneos-version-min/mios-simulator-version-min/g' usage_examples/ios_toolchain/wrapper.c && \
+    #usage_examples/ios_toolchain/build.sh /root/files/iPhoneSimulator${IOS_SDK}.sdk.tar.xz arm64 && \
+    #mkdir -p /root/ioscross/arm64_sim && \
+    #mv usage_examples/ios_toolchain/target/* /root/ioscross/arm64_sim && \
+    #mkdir /root/ioscross/arm64_sim/usr && \
+    #ln -s /root/ioscross/arm64_sim/bin /root/ioscross/arm64_sim/usr/bin && \
+    # x86_64 simulator
     sed -i 's#^TRIPLE=.*#TRIPLE="x86_64-apple-darwin11"#' usage_examples/ios_toolchain/build.sh && \
     usage_examples/ios_toolchain/build.sh /root/files/iPhoneSimulator${IOS_SDK}.sdk.tar.xz x86_64 && \
     mkdir -p /root/ioscross/x86_64_sim && \
@@ -39,8 +44,8 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
     export MONO_SOURCE_ROOT=/root/${mono_version} && \
     python3 ios.py configure -j --verbose --target=arm64 --ios-toolchain ${IOSCROSS_ROOT}/arm64 --ios-sdk ${IOSCROSS_ROOT}/arm64/SDK/iPhoneOS${IOS_SDK}.sdk --osx-toolchain ${OSXCROSS_ROOT} && \
     python3 ios.py make -j --verbose --target=arm64 && \
-    python3 ios.py configure -j --verbose --target=arm64-sim --ios-toolchain ${IOSCROSS_ROOT}/arm64_sim --ios-sdk ${IOSCROSS_ROOT}/arm64_sim/SDK/iPhoneOS${IOS_SDK}.sdk --osx-toolchain ${OSXCROSS_ROOT} && \
-    python3 ios.py make -j --verbose --target=arm64-sim && \
+    #python3 ios.py configure -j --verbose --target=arm64-sim --ios-toolchain ${IOSCROSS_ROOT}/arm64_sim --ios-sdk ${IOSCROSS_ROOT}/arm64_sim/SDK/iPhoneOS${IOS_SDK}.sdk --osx-toolchain ${OSXCROSS_ROOT} && \
+    #python3 ios.py make -j --verbose --target=arm64-sim && \
     python3 ios.py configure -j --verbose --target=x86_64 --ios-toolchain ${IOSCROSS_ROOT}/x86_64_sim --ios-sdk ${IOSCROSS_ROOT}/x86_64_sim/SDK/iPhoneOS${IOS_SDK}.sdk --osx-toolchain ${OSXCROSS_ROOT} && \
     python3 ios.py make -j --verbose --target=x86_64 && \
     python3 bcl.py make -j --product=ios && \


### PR DESCRIPTION
We have to wait for a resolution to https://github.com/tpoechtrager/cctools-port/issues/102
or try a custom LLVM build with the proposed patch in that issue.

Matching scripts update: https://github.com/godotengine/godot-build-scripts/pull/41