### PR TITLE
Windows: Update godot-mono-builds with fixed copy_bcl for win32

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -11,8 +11,10 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
     cd /root/${mono_version}/godot-mono-builds && \
     python3 windows.py configure -j --target=x86_64 --target=x86 --mxe-prefix=/usr && \
     python3 windows.py make -j --target=x86_64 --target=x86 --mxe-prefix=/usr && \
+    # 'desktop' bcl needed to build 'desktop-win32', then we can remove it.
     python3 bcl.py make -j --product=desktop && \
     python3 bcl.py make -j --product=desktop-win32 && \
+    rm -rf /root/mono-installs/desktop-bcl && \
     python3 windows.py copy-bcl --target=x86_64 --target=x86 && \
     cd /root && \
     rm -rf /root/${mono_version}

--- a/build.sh
+++ b/build.sh
@@ -97,7 +97,7 @@ if [ ! -e ${mono_root} ]; then
   # Set up godot-mono-builds in tree
   git clone --progress https://github.com/godotengine/godot-mono-builds
   pushd godot-mono-builds
-  git checkout release/mono-6.12.0.147
+  git checkout 2bf7d71c7c3ba6cef7916562b0978139a80bd90e
   export MONO_SOURCE_ROOT=${mono_root}
   python3 patch_mono.py
   popd


### PR DESCRIPTION
Includes https://github.com/godotengine/godot-mono-builds/pull/46, will rebase to point to the merge commit once merged.