### PR TITLE
Switch xcode-packer to use Fedora 33 (for the compat-openssl10-devel package)

### DIFF
--- a/Dockerfile.xcode
+++ b/Dockerfile.xcode
@@ -1,5 +1,13 @@
 ARG img_version
-FROM godot-fedora:${img_version}
+#FROM godot-fedora:${img_version}
+FROM fedora:33
+
+WORKDIR /root
+
+RUN dnf -y upgrade --setopt=install_weak_deps=False && \
+    dnf -y install --setopt=install_weak_deps=False \
+      bash bzip2 curl file findutils git make nano patch pkgconfig python3-pip unzip which xz && \
+    pip install scons==4.1.0
 
 RUN dnf -y install --setopt=install_weak_deps=False \
       autoconf automake libtool clang cmake fuse fuse-devel libxml2-devel libicu-devel compat-openssl10-devel bzip2-devel kmod cpio && \


### PR DESCRIPTION
This image failed to build for me on `godot-fedora` because it appears that the compat-openssl10-devel package isn't available in Fedora 34. Switching to Fedora 33 allowed it to build for me!

I don't know if this is the best solution, but since this image is only used to build some files from the XCode.xip, it seems like it could be acceptable?