### PR TITLE
Xcode: Fix xar compatibility with openssl 1.1

### DIFF
--- a/Dockerfile.xcode
+++ b/Dockerfile.xcode
@@ -2,10 +2,12 @@ ARG img_version
 FROM godot-fedora:${img_version}
 
 RUN dnf -y install --setopt=install_weak_deps=False \
-      autoconf automake libtool clang cmake fuse fuse-devel libxml2-devel libicu-devel compat-openssl10-devel bzip2-devel kmod cpio && \
+      autoconf automake libtool clang cmake fuse fuse-devel libxml2-devel libicu-devel openssl-devel bzip2-devel kmod cpio && \
     git clone --progress https://github.com/mackyle/xar.git && \
     cd xar/xar && \
     git checkout 66d451dab1ef859dd0c83995f2379335d35e53c9 && \
+    # Fix compat with OpenSSL 1.1 (https://github.com/mackyle/xar/pull/21).
+    sed -i configure.ac -e "s/OpenSSL_add_all_ciphers/OPENSSL_init_crypto/" && \
     ./autogen.sh --prefix=/usr && \
     make -j && make install && \
     cd /root && \


### PR DESCRIPTION
Makes the script compatible with the current Fedora 34 base image.

Supersedes #88.