### PR TITLE
Xcode: Install `xar` package from Fedora

### DIFF
--- a/Dockerfile.xcode
+++ b/Dockerfile.xcode
@@ -2,13 +2,7 @@ ARG img_version
 FROM godot-fedora:${img_version}
 
 RUN dnf -y install --setopt=install_weak_deps=False \
-      autoconf automake libtool clang cmake fuse fuse-devel libxml2-devel libicu-devel compat-openssl10-devel bzip2-devel kmod cpio && \
-    git clone --progress https://github.com/mackyle/xar.git && \
-    cd xar/xar && \
-    git checkout 66d451dab1ef859dd0c83995f2379335d35e53c9 && \
-    ./autogen.sh --prefix=/usr && \
-    make -j && make install && \
-    cd /root && \
+      clang xar xar-devel xz-devel cpio && \
     git clone --progress https://github.com/NiklasRosenstein/pbzx && \
     cd pbzx && \
     git checkout 2a4d7c3300c826d918def713a24d25c237c8ed53 && \


### PR DESCRIPTION
It's better maintained than https://github.com/mackyle/xar and that saves us
some work.

Supersedes #88 and #89.

---

Note: Still testing that the generated SDK tarballs can be used to build the macOS and iOS containers properly.

*Edit:* I could build osxcross and ioscross without issue so it seems like the extracted SDKs are valid.