### PR TITLE
Upgrade to Fedora 36 and Mono 6.12.0.178, newer toolchains

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,10 +1,10 @@
-FROM fedora:34
+FROM fedora:36
 
 WORKDIR /root
 
 RUN dnf -y upgrade --setopt=install_weak_deps=False && \
     dnf -y install --setopt=install_weak_deps=False \
       bash bzip2 curl file findutils git make nano patch pkgconfig python3-pip unzip which xz && \
-    pip install scons==4.1.0
+    pip install scons==4.3.0
 
 CMD /bin/bash

--- a/Dockerfile.export
+++ b/Dockerfile.export
@@ -2,6 +2,7 @@ ARG img_version
 FROM godot-fedora:${img_version}
 
 RUN dnf -y install --setopt=install_weak_deps=False \
-      xorg-x11-server-Xvfb mesa-dri-drivers libXcursor libXinerama libXrandr libXi alsa-lib pulseaudio-libs java-1.8.0-openjdk-devel
+      xorg-x11-server-Xvfb libXcursor libXinerama libXrandr libXi \
+      alsa-lib pulseaudio-libs mesa-dri-drivers java-11-openjdk-devel
 
 CMD /bin/bash

--- a/Dockerfile.ios
+++ b/Dockerfile.ios
@@ -9,7 +9,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
       automake autoconf clang gcc gcc-c++ gcc-objc gcc-objc++ cmake libicu-devel libtool libxml2-devel llvm-devel openssl-devel perl python yasm && \
     git clone --progress https://github.com/tpoechtrager/cctools-port.git && \
     cd /root/cctools-port && \
-    git checkout 236a426c1205a3bfcf0dbb2e2faf2296f0a100e5 && \
+    git checkout 04663295d0425abfac90a42440a7ec02d7155fea && \
     # arm64 device
     usage_examples/ios_toolchain/build.sh /root/files/iPhoneOS${IOS_SDK}.sdk.tar.xz arm64 && \
     mkdir -p /root/ioscross/arm64 && \
@@ -52,7 +52,7 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
       --ios-toolchain ${IOSCROSS_ROOT}/x86_64_sim --ios-sdk ${IOSCROSS_ROOT}/x86_64_sim/SDK/iPhoneOS${IOS_SDK}.sdk && \
     python3 ios.py make -j --target=x86_64 && \
     python3 bcl.py make -j --product=ios && \
-    # TODO: Emable once godot-mono-builds supports osxcross for the cross-compiler.
+    # TODO: Enable once godot-mono-builds supports osxcross for the cross-compiler.
     # It requires having a build of libclang with support for iOS arm64 + changes to the build scripts.
     #python3 ios.py configure -j --target=cross-arm64 --ios-toolchain ${IOSCROSS_ROOT}/arm64 --ios-sdk ${IOSCROSS_ROOT}/arm64/SDK/iPhoneOS${IOS_SDK}.sdk --osx-toolchain ${OSXCROSS_ROOT} && \
     #python3 ios.py make -j --target=cross-arm64 && \
@@ -61,7 +61,7 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
 
 # Until we can build the cross-compiler, we include a pre-made build in the container.
 RUN mkdir -p /root/aot-compilers/iphone-arm64 && \
-    curl -LO https://github.com/godotengine/godot-mono-builds/releases/download/release-c3a9d31/ios-cross-arm64.zip && \
+    curl -LO https://github.com/godotengine/godot-mono-builds/releases/download/release-c865201/ios-cross-arm64.zip && \
     dnf -y install --setopt=install_weak_deps=False p7zip && \
     7za e ios-cross-arm64.zip ios-cross-arm64-release/bin/aarch64-apple-darwin-mono-sgen -o/root/aot-compilers/iphone-arm64 && \
     rm ios-cross-arm64.zip

--- a/Dockerfile.javascript
+++ b/Dockerfile.javascript
@@ -3,12 +3,14 @@ FROM godot-mono:${img_version}
 
 ARG mono_version
 
-ENV EMSCRIPTEN_CLASSICAL=2.0.25
+ENV EMSCRIPTEN_CLASSICAL=3.1.10
 ENV EMSCRIPTEN_MONO=1.39.9
 
 RUN if [ -z "${mono_version}" ]; then printf "\n\nArgument mono_version is mandatory!\n\n"; exit 1; fi && \
+    # We need to downgrade to autoconf 2.69 from F35 as autoconf 2.71 from F36 breaks `--host wasm32`.
     dnf -y install --setopt=install_weak_deps=False \
-      java-openjdk && \
+      https://kojipkgs.fedoraproject.org//packages/autoconf/2.69/37.fc35/noarch/autoconf-2.69-37.fc35.noarch.rpm \
+      https://kojipkgs.fedoraproject.org//packages/automake/1.16.2/5.fc35/noarch/automake-1.16.2-5.fc35.noarch.rpm && \
     git clone --branch ${EMSCRIPTEN_CLASSICAL} --progress https://github.com/emscripten-core/emsdk emsdk_${EMSCRIPTEN_CLASSICAL} && \
     cp -r emsdk_${EMSCRIPTEN_CLASSICAL} emsdk_${EMSCRIPTEN_MONO} && \
     emsdk_${EMSCRIPTEN_CLASSICAL}/emsdk install ${EMSCRIPTEN_CLASSICAL} && \

--- a/Dockerfile.mono-glue
+++ b/Dockerfile.mono-glue
@@ -4,6 +4,7 @@ FROM godot-mono:${img_version}
 ARG mono_version
 
 RUN dnf -y install --setopt=install_weak_deps=False \
-      xorg-x11-server-Xvfb libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel libXi-devel alsa-lib-devel pulseaudio-libs-devel libudev-devel mesa-libGL-devel mesa-libGLU-devel mesa-dri-drivers
+      xorg-x11-server-Xvfb libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel libXi-devel \
+      alsa-lib-devel pulseaudio-libs-devel libudev-devel mesa-libGL-devel mesa-libGLU-devel mesa-dri-drivers
 
 CMD /bin/bash

--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -8,8 +8,9 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
       automake autoconf bzip2-devel clang libicu-devel libtool libxml2-devel llvm-devel openssl-devel yasm && \
     git clone --progress https://github.com/tpoechtrager/osxcross.git && \
     cd /root/osxcross && \
-    git checkout 0f87f567dfaf98460244471ad6c0f4311d62079c && \
+    git checkout 610542781e0eabc6968b0c0719bbc8d25c992025 && \
     ln -s /root/files/MacOSX11.1.sdk.tar.xz /root/osxcross/tarballs && \
+    sed -i build_compiler_rt.sh -e "s@BRANCH=main@BRANCH=release/14.x@g" && \
     UNATTENDED=1 ./build.sh && \
     ./build_compiler_rt.sh
 

--- a/build.sh
+++ b/build.sh
@@ -89,10 +89,8 @@ if [ ! -e ${mono_root} ]; then
   # Set up godot-mono-builds in tree
   git clone --progress https://github.com/godotengine/godot-mono-builds
   pushd godot-mono-builds
-  git checkout 0d72e71a50f2b76f10cd348a3bbb6ed81209b5e4
+  git checkout c865201ebaa29135e6e72787d46ba464f39e2a15
   export MONO_SOURCE_ROOT=${mono_root}
-  # Fix https://github.com/godotengine/build-containers/issues/95
-  git revert --no-commit f63f4e2e440197048646094b9d62a9f80eb88b0b
   python3 patch_mono.py
   popd
   popd


### PR DESCRIPTION
- F36 gives us MinGW GCC 11.2.1 and binutils 2.37 for Windows builds.
  * Had to downgrade autotools to F35 version for Mono wasm builds.
- OSX and iOS builds now use LLVM 14 for osxcross.
- Emscripten updated to 3.1.10 for classical builds (still using
  1.39.9 for Mono).
- Mono 6.12.0.178, and updated godot-mono-builds to fix issue with
  btls-lib on macOS ARM64 (fixes https://github.com/godotengine/build-containers/issues/95).
- SCons 4.3.0.
- ~Add `osslsigncode` to Linux image for use in godot-build-scripts.~ *Edit:* Removed, I ended up not using it in https://github.com/godotengine/godot-build-scripts/pull/53
- Linux toolchains not updated yet, need to prepare a new buildroot
  with latest GCC/binutils.

Syncs with latest godot-mono-builds: https://github.com/godotengine/godot-mono-builds/releases/tag/release-c865201

F36 should be released **today**, and I've been testing this update with a pre-release snapshot. I'll rebuild containers when F36 is released as stable.

I've actually tested these scripts with Mono 6.12.0.**177**, but I'll also rebuild against **178** together with F36 stable.

osxcross build failed on F36 because it's not ready for LLVM 14 stable yet, I sent a PR upstream to fix it (just fixing up with `sed` in these scripts until the upstream PR is merged): https://github.com/tpoechtrager/osxcross/pull/341

autotools 2.71 is a big compat breaking release and that's breaking some stuff in the Mono wasm builds, so I had to revert it to the F35 versions of autotools and automake (which thankfully downgrade and run fine on F36).