### PR TITLE
Set base to Fedora 35 for now, F36 still a bit too new

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM fedora:36
+FROM fedora:35
 
 WORKDIR /root
 

--- a/Dockerfile.javascript
+++ b/Dockerfile.javascript
@@ -7,10 +7,6 @@ ENV EMSCRIPTEN_CLASSICAL=3.1.10
 ENV EMSCRIPTEN_MONO=1.39.9
 
 RUN if [ -z "${mono_version}" ]; then printf "\n\nArgument mono_version is mandatory!\n\n"; exit 1; fi && \
-    # We need to downgrade to autoconf 2.69 from F35 as autoconf 2.71 from F36 breaks `--host wasm32`.
-    dnf -y install --setopt=install_weak_deps=False \
-      https://kojipkgs.fedoraproject.org//packages/autoconf/2.69/37.fc35/noarch/autoconf-2.69-37.fc35.noarch.rpm \
-      https://kojipkgs.fedoraproject.org//packages/automake/1.16.2/5.fc35/noarch/automake-1.16.2-5.fc35.noarch.rpm && \
     git clone --branch ${EMSCRIPTEN_CLASSICAL} --progress https://github.com/emscripten-core/emsdk emsdk_${EMSCRIPTEN_CLASSICAL} && \
     cp -r emsdk_${EMSCRIPTEN_CLASSICAL} emsdk_${EMSCRIPTEN_MONO} && \
     emsdk_${EMSCRIPTEN_CLASSICAL}/emsdk install ${EMSCRIPTEN_CLASSICAL} && \


### PR DESCRIPTION
Notably LLVM 14 on F36 doesn't seem to play nice with macOS builds.
We probably need to wait for Xcode 14 to have support for LLVM 14.

Going back to F35 also avoids issues with autoconf 2.71.