### PR TITLE
Set base to Fedora 36, F35 had worse issues

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM fedora:35
+FROM fedora:36
 
 WORKDIR /root
 

--- a/Dockerfile.javascript
+++ b/Dockerfile.javascript
@@ -7,6 +7,10 @@ ENV EMSCRIPTEN_CLASSICAL=3.1.10
 ENV EMSCRIPTEN_MONO=1.39.9
 
 RUN if [ -z "${mono_version}" ]; then printf "\n\nArgument mono_version is mandatory!\n\n"; exit 1; fi && \
+    # We need to downgrade to autoconf 2.69 from F35 as autoconf 2.71 from F36 breaks `--host wasm32`.
+    dnf -y install --setopt=install_weak_deps=False \
+      https://kojipkgs.fedoraproject.org//packages/autoconf/2.69/37.fc35/noarch/autoconf-2.69-37.fc35.noarch.rpm \
+      https://kojipkgs.fedoraproject.org//packages/automake/1.16.2/5.fc35/noarch/automake-1.16.2-5.fc35.noarch.rpm && \
     git clone --branch ${EMSCRIPTEN_CLASSICAL} --progress https://github.com/emscripten-core/emsdk emsdk_${EMSCRIPTEN_CLASSICAL} && \
     cp -r emsdk_${EMSCRIPTEN_CLASSICAL} emsdk_${EMSCRIPTEN_MONO} && \
     emsdk_${EMSCRIPTEN_CLASSICAL}/emsdk install ${EMSCRIPTEN_CLASSICAL} && \

--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -5,15 +5,19 @@ ARG mono_version
 
 RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
     dnf -y install --setopt=install_weak_deps=False \
-      automake autoconf bzip2-devel clang libicu-devel libtool libxml2-devel llvm-devel openssl-devel yasm && \
+      automake autoconf bzip2-devel cmake libicu-devel libtool libxml2-devel openssl-devel yasm && \
     git clone --progress https://github.com/tpoechtrager/osxcross.git && \
     cd /root/osxcross && \
     git checkout 610542781e0eabc6968b0c0719bbc8d25c992025 && \
     ln -s /root/files/MacOSX12.3.sdk.tar.xz /root/osxcross/tarballs && \
     sed -i build.sh -e "/  12.1\*/a   12.3*)  TARGET=darwin21.4; X86_64H_SUPPORTED=1; I386_SUPPORTED=0; ARM_SUPPORTED=1; NEED_TAPI_SUPPORT=1; OSX_VERSION_MIN_INT=10.9;  ;;" && \
     sed -i build_compiler_rt.sh -e "s@BRANCH=main@BRANCH=release/14.x@g" && \
-    UNATTENDED=1 ./build.sh && \
-    ./build_compiler_rt.sh
+    export UNATTENDED=1 && \
+    # Custom build to ensure we have Clang version matching Xcode SDK.
+    CLANG_VERSION=13.0.1 ENABLE_CLANG_INSTALL=1 INSTALLPREFIX=/usr ./build_clang.sh && \
+    ./build.sh && \
+    ./build_compiler_rt.sh && \
+    rm -rf /root/osxcross/build
 
 ENV OSXCROSS_ROOT=/root/osxcross
 ENV PATH="/root/osxcross/target/bin:${PATH}"


### PR DESCRIPTION
This reverts #105 as we found that the MinGW/GCC/binutils
combinations in Fedora 35 generates broken Windows binaries:
https://github.com/godotengine/godot/issues/61176

To workaround the issue with LLVM 14 on F36, we build Clang 13.0.1
from source for osxcross in the OSX container. This matches Xcode 13.