### PR TITLE
Update to Android NDK r23, Emscripten 3.1.14

### DIFF
--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -4,27 +4,33 @@ FROM godot-mono:${img_version}
 ARG mono_version
 
 ENV ANDROID_SDK_ROOT=/root/sdk
-ENV ANDROID_NDK_VERSION=21.4.7075529
+ENV ANDROID_NDK_VERSION=23.2.8568313
 ENV ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk/${ANDROID_NDK_VERSION}
 
 RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
     dnf -y install --setopt=install_weak_deps=False \
       java-11-openjdk-devel ncurses-compat-libs && \
     mkdir -p sdk && cd sdk && \
-    export CMDLINETOOLS=commandlinetools-linux-7302050_latest.zip && \
+    export CMDLINETOOLS=commandlinetools-linux-8512546_latest.zip && \
     curl -LO https://dl.google.com/android/repository/${CMDLINETOOLS} && \
     unzip ${CMDLINETOOLS} && \
     rm ${CMDLINETOOLS} && \
     yes | cmdline-tools/bin/sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" --licenses && \
-    cmdline-tools/bin/sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" "ndk;${ANDROID_NDK_VERSION}" 'cmdline-tools;latest' 'build-tools;30.0.3' 'platforms;android-30' 'cmake;3.18.1'
+    cmdline-tools/bin/sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" "ndk;${ANDROID_NDK_VERSION}" 'cmdline-tools;latest' 'build-tools;32.0.0' 'platforms;android-32' 'cmake;3.18.1'
 
-RUN cp -a /root/files/${mono_version} /root && \
+# Mono still not compatible with NDK r22+:
+# https://github.com/godotengine/godot-mono-builds/issues/68
+RUN export ANDROID_NDK_VERSION_MONO=21.4.7075529 && \
+    export ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk/${ANDROID_NDK_VERSION_MONO} && \
+    /root/sdk/cmdline-tools/bin/sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" "ndk;${ANDROID_NDK_VERSION_MONO}" && \
+    cp -a /root/files/${mono_version} /root && \
     export MONO_SOURCE_ROOT=/root/${mono_version} && \
     cd /root/${mono_version}/godot-mono-builds && \
     python3 android.py configure -j --target=all-runtime && \
     python3 android.py make -j --target=all-runtime && \
     python3 bcl.py make -j --product=android && \
     cd /root && \
-    rm -rf /root/${mono_version}
+    rm -rf /root/${mono_version} && \
+    rm -rf ${ANDROID_NDK_ROOT}
 
 CMD /bin/bash

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -2,8 +2,7 @@ FROM fedora:36
 
 WORKDIR /root
 
-RUN dnf -y upgrade --setopt=install_weak_deps=False && \
-    dnf -y install --setopt=install_weak_deps=False \
+RUN dnf -y install --setopt=install_weak_deps=False \
       bash bzip2 curl file findutils git make nano patch pkgconfig python3-pip unzip which xz && \
     pip install scons==4.3.0
 

--- a/Dockerfile.ios
+++ b/Dockerfile.ios
@@ -63,7 +63,7 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
 
 # Until we can build the cross-compiler, we include a pre-made build in the container.
 RUN mkdir -p /root/aot-compilers/iphone-arm64 && \
-    curl -LO https://github.com/godotengine/godot-mono-builds/releases/download/release-7533d08/ios-cross-arm64.zip && \
+    curl -LO https://github.com/godotengine/godot-mono-builds/releases/download/release-fcf205c/ios-cross-arm64.zip && \
     dnf -y install --setopt=install_weak_deps=False p7zip && \
     7za e ios-cross-arm64.zip ios-cross-arm64-release/bin/aarch64-apple-darwin-mono-sgen -o/root/aot-compilers/iphone-arm64 && \
     rm ios-cross-arm64.zip

--- a/Dockerfile.javascript
+++ b/Dockerfile.javascript
@@ -3,7 +3,7 @@ FROM godot-mono:${img_version}
 
 ARG mono_version
 
-ENV EMSCRIPTEN_CLASSICAL=3.1.10
+ENV EMSCRIPTEN_CLASSICAL=3.1.14
 ENV EMSCRIPTEN_MONO=1.39.9
 
 RUN if [ -z "${mono_version}" ]; then printf "\n\nArgument mono_version is mandatory!\n\n"; exit 1; fi && \

--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -8,10 +8,8 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
       automake autoconf bzip2-devel cmake libicu-devel libtool libxml2-devel openssl-devel yasm && \
     git clone --progress https://github.com/tpoechtrager/osxcross.git && \
     cd /root/osxcross && \
-    git checkout 610542781e0eabc6968b0c0719bbc8d25c992025 && \
+    git checkout 17bb5e2d0a46533c1dd525cf4e9a80d88bd9f00e && \
     ln -s /root/files/MacOSX12.3.sdk.tar.xz /root/osxcross/tarballs && \
-    sed -i build.sh -e "/  12.1\*/a   12.3*)  TARGET=darwin21.4; X86_64H_SUPPORTED=1; I386_SUPPORTED=0; ARM_SUPPORTED=1; NEED_TAPI_SUPPORT=1; OSX_VERSION_MIN_INT=10.9;  ;;" && \
-    sed -i build_compiler_rt.sh -e "s@BRANCH=main@BRANCH=release/14.x@g" && \
     export UNATTENDED=1 && \
     # Custom build to ensure we have Clang version matching Xcode SDK.
     CLANG_VERSION=13.0.1 ENABLE_CLANG_INSTALL=1 INSTALLPREFIX=/usr ./build_clang.sh && \

--- a/build.sh
+++ b/build.sh
@@ -62,7 +62,7 @@ if [ ! -e ${mono_root} ]; then
   # Set up godot-mono-builds in tree
   git clone --progress https://github.com/godotengine/godot-mono-builds
   pushd godot-mono-builds
-  git checkout 2fa04b9dc73a9e84037ef165c88f0cddfaa8705b
+  git checkout fcf205c105bb2eb88dc85975887170c42675d245
   export MONO_SOURCE_ROOT=${mono_root}
   python3 patch_mono.py
   popd


### PR DESCRIPTION
Keeping NDK r21 for building Mono itself as it's not compatible yet
with NDK r22+ (see https://github.com/godotengine/godot-mono-builds/issues/68).