### PR TITLE
Web: Downgrade to Emscripten 3.1.18

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,7 +1,7 @@
 ARG img_version
 FROM godot-fedora:${img_version}
 
-ENV EMSCRIPTEN_VERSION=3.1.20
+ENV EMSCRIPTEN_VERSION=3.1.18
 
 RUN git clone --branch ${EMSCRIPTEN_VERSION} --progress https://github.com/emscripten-core/emsdk && \
     emsdk/emsdk install ${EMSCRIPTEN_VERSION} && \

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ These are the toolchains currently in use for Godot 4.0 and later:
 - SCons: 4.4.0
 - Linux: GCC 10.2.0 built against glibc 2.19, binutils 2.35.1, from our own [Linux SDK](https://github.com/godotengine/buildroot)
 - Windows: MinGW 9.0.0, GCC 11.2.0, binutils 2.37
-- HTML5: Emscripten 3.1.20
+- Web: Emscripten 3.1.18
 - Android: Android NDK 23.2.8568313, build-tools 32.0.0, platform android-32, CMake 3.18.1
 - macOS: Xcode 13.3.1 with LLVM Clang 13.0.1, MacOSX SDK 12.3
 - iOS: Xcode 13.3.1 with LLVM Clang 13.0.1, iPhoneOS SDK 15.4


### PR DESCRIPTION
Emscripten 3.1.19 and 3.1.20 have a showstopping regression that breaks calling our main function for the editor build.