### PR TITLE
Xcode: Update to Xcode 14.1, macOS 13.0, iOS 16.1

### DIFF
--- a/Dockerfile.ios
+++ b/Dockerfile.ios
@@ -1,13 +1,13 @@
 ARG img_version
 FROM godot-osx:${img_version}
 
-ENV IOS_SDK=15.4
+ENV IOS_SDK=16.1
 
 RUN dnf -y install --setopt=install_weak_deps=False \
       automake autoconf gcc gcc-c++ gcc-objc gcc-objc++ cmake libicu-devel libtool libxml2-devel openssl-devel perl python yasm && \
     git clone --progress https://github.com/tpoechtrager/cctools-port.git && \
     cd /root/cctools-port && \
-    git checkout 04663295d0425abfac90a42440a7ec02d7155fea && \
+    git checkout 11c93763d7e7ce7305163341d08052374e4712de && \
     # arm64 device
     usage_examples/ios_toolchain/build.sh /root/files/iPhoneOS${IOS_SDK}.sdk.tar.xz arm64 && \
     mkdir -p /root/ioscross/arm64 && \

--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -2,14 +2,15 @@ ARG img_version
 FROM godot-fedora:${img_version}
 
 RUN dnf -y install --setopt=install_weak_deps=False \
-      automake autoconf bzip2-devel cmake gcc gcc-c++ libicu-devel libtool libxml2-devel openssl-devel yasm && \
+      automake autoconf bzip2-devel cmake gcc gcc-c++ libicu-devel libtool libxml2-devel openssl-devel yasm \
+      clang llvm-devel && \
     git clone --progress https://github.com/tpoechtrager/osxcross.git && \
     cd /root/osxcross && \
-    git checkout 17bb5e2d0a46533c1dd525cf4e9a80d88bd9f00e && \
-    ln -s /root/files/MacOSX12.3.sdk.tar.xz /root/osxcross/tarballs && \
+    git checkout 50e86ebca7d14372febd0af8cd098705049161b9 && \
+    ln -s /root/files/MacOSX13.0.sdk.tar.xz /root/osxcross/tarballs && \
     export UNATTENDED=1 && \
-    # Custom build to ensure we have Clang version matching Xcode SDK.
-    CLANG_VERSION=13.0.1 ENABLE_CLANG_INSTALL=1 INSTALLPREFIX=/usr ./build_clang.sh && \
+    # Custom build Clang if the Fedora version doesn't match the Xcode SDK.
+    #CLANG_VERSION=14.0.6 ENABLE_CLANG_INSTALL=1 INSTALLPREFIX=/usr ./build_clang.sh && \
     ./build.sh && \
     ./build_compiler_rt.sh && \
     rm -rf /root/osxcross/build

--- a/Dockerfile.xcode
+++ b/Dockerfile.xcode
@@ -3,7 +3,7 @@ FROM godot-fedora:${img_version}
 
 RUN dnf -y install --setopt=install_weak_deps=False \
       clang xar xar-devel xz-devel cpio && \
-    git clone --progress https://github.com/NiklasRosenstein/pbzx && \
+    git clone --progress https://github.com/nrosenstein-stuff/pbzx && \
     cd pbzx && \
     git checkout 2a4d7c3300c826d918def713a24d25c237c8ed53 && \
     clang -O3 -llzma -lxar -I /usr/local/include pbzx.c -o pbzx

--- a/build.sh
+++ b/build.sh
@@ -54,9 +54,9 @@ $podman_build -t godot-windows:${img_version} -f Dockerfile.windows . 2>&1 | tee
 $podman_build -t godot-web:${img_version} -f Dockerfile.web . 2>&1 | tee logs/web.log
 $podman_build -t godot-android:${img_version} -f Dockerfile.android . 2>&1 | tee logs/android.log
 
-XCODE_SDK=13.3.1
-OSX_SDK=12.3
-IOS_SDK=15.4
+XCODE_SDK=14.1
+OSX_SDK=13.0
+IOS_SDK=16.1
 if [ ! -e files/MacOSX${OSX_SDK}.sdk.tar.xz ] || [ ! -e files/iPhoneOS${IOS_SDK}.sdk.tar.xz ] || [ ! -e files/iPhoneSimulator${IOS_SDK}.sdk.tar.xz ]; then
   if [ ! -e files/Xcode_${XCODE_SDK}.xip ]; then
     echo "files/Xcode_${XCODE_SDK}.xip is required. It can be downloaded from https://developer.apple.com/download/more/ with a valid apple ID."


### PR DESCRIPTION
Use Fedora 36's Clang since it provides version 14.0.5 which fits the version used by Xcode 14.1.