### PR TITLE
macOS: Update godot-mono-builds to fix missing ARM64 btls lib

### DIFF
--- a/Dockerfile.ios
+++ b/Dockerfile.ios
@@ -63,7 +63,7 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
 
 # Until we can build the cross-compiler, we include a pre-made build in the container.
 RUN mkdir -p /root/aot-compilers/iphone-arm64 && \
-    curl -LO https://github.com/godotengine/godot-mono-builds/releases/download/release-fcf205c/ios-cross-arm64.zip && \
+    curl -LO https://github.com/godotengine/godot-mono-builds/releases/download/release-8767196/ios-cross-arm64.zip && \
     dnf -y install --setopt=install_weak_deps=False p7zip && \
     7za e ios-cross-arm64.zip ios-cross-arm64-release/bin/aarch64-apple-darwin-mono-sgen -o/root/aot-compilers/iphone-arm64 && \
     rm ios-cross-arm64.zip

--- a/build.sh
+++ b/build.sh
@@ -62,7 +62,7 @@ if [ ! -e ${mono_root} ]; then
   # Set up godot-mono-builds in tree
   git clone --progress https://github.com/godotengine/godot-mono-builds
   pushd godot-mono-builds
-  git checkout 4bf530983a52d09f4f63aea032aee9be47931cbd
+  git checkout 8767196960fb884ae95f337ee10cb131ae720086
   export MONO_SOURCE_ROOT=${mono_root}
   python3 patch_mono.py
   popd


### PR DESCRIPTION
Namely the fix for https://github.com/godotengine/godot-mono-builds/issues/79.