### PR TITLE
build: support specifying subset of platforms

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -43,36 +43,45 @@ done
 
 mkdir -p logs
 
-# You can add --no-cache  as an option to podman_build below to rebuild all containers from scratch
-export podman_build="$podman build --build-arg img_version=${img_version} -v ${files_root}:/root/files:z"
+"$podman" build -t godot-fedora:${img_version} -f Dockerfile.base . 2>&1 | tee logs/base.log
 
-$podman build -t godot-fedora:${img_version} -f Dockerfile.base . 2>&1 | tee logs/base.log
-$podman_build -t godot-export:${img_version} -f Dockerfile.export . 2>&1 | tee logs/export.log
+podman_build() {
+  # You can add --no-cache  as an option to podman_build below to rebuild all containers from  scratch.
+  "$podman" build \
+  --build-arg img_version=${img_version} \
+  -v "${files_root}":/root/files:z \
+  -t "$1:${img_version}" \
+  -f Dockerfile."$2" . \
+  2>&1 | tee logs/"$2".log
+}
 
-$podman_build -t godot-linux:${img_version} -f Dockerfile.linux . 2>&1 | tee logs/linux.log
-$podman_build -t godot-windows:${img_version} -f Dockerfile.windows . 2>&1 | tee logs/windows.log
-$podman_build -t godot-web:${img_version} -f Dockerfile.web . 2>&1 | tee logs/web.log
-$podman_build -t godot-android:${img_version} -f Dockerfile.android . 2>&1 | tee logs/android.log
+podman_build godot-export export
+
+podman_build godot-linux linux
+podman_build godot-windows windows
+
+podman_build godot-web web
+podman_build godot-android android
 
 XCODE_SDK=14.1
 OSX_SDK=13.0
 IOS_SDK=16.1
-if [ ! -e ${files_root}/MacOSX${OSX_SDK}.sdk.tar.xz ] || [ ! -e ${files_root}/iPhoneOS${IOS_SDK}.sdk.tar.xz ] || [ ! -e ${files_root}/iPhoneSimulator${IOS_SDK}.sdk.tar.xz ]; then
-  if [ ! -e ${files_root}/Xcode_${XCODE_SDK}.xip ]; then
+if [ ! -e "${files_root}"/MacOSX${OSX_SDK}.sdk.tar.xz ] || [ ! -e "${files_root}"/iPhoneOS${IOS_SDK}.sdk.tar.xz ] || [ ! -e "${files_root}"/iPhoneSimulator${IOS_SDK}.sdk.tar.xz ]; then
+  if [ ! -e "${files_root}"/Xcode_${XCODE_SDK}.xip ]; then
     echo "files/Xcode_${XCODE_SDK}.xip is required. It can be downloaded from https://developer.apple.com/download/more/ with a valid apple ID."
     exit 1
   fi
 
   echo "Building OSX and iOS SDK packages. This will take a while"
-  $podman_build -t godot-xcode-packer:${img_version} -f Dockerfile.xcode . 2>&1 | tee logs/xcode.log
-  $podman run -it --rm -v ${files_root}:/root/files:z -e XCODE_SDKV="${XCODE_SDK}" -e OSX_SDKV="${OSX_SDK}" -e IOS_SDKV="${IOS_SDK}" godot-xcode-packer:${img_version} 2>&1 | tee logs/xcode_packer.log
+  podman_build godot-xcode-packer xcode
+  $podman run -it --rm -v "${files_root}":/root/files:z -e XCODE_SDKV="${XCODE_SDK}" -e OSX_SDKV="${OSX_SDK}" -e IOS_SDKV="${IOS_SDK}" godot-xcode-packer:${img_version} 2>&1 | tee logs/xcode_packer.log
 fi
 
-$podman_build -t godot-osx:${img_version} -f Dockerfile.osx . 2>&1 | tee logs/osx.log
-$podman_build -t godot-ios:${img_version} -f Dockerfile.ios . 2>&1 | tee logs/ios.log
+podman_build godot-osx osx
+podman_build godot-ios ios
 
 if [ "${build_msvc}" != "0" ]; then
-  if [ ! -e ${files_root}/msvc2017.tar ]; then
+  if [ ! -e "${files_root}"/msvc2017.tar ]; then
     echo
     echo "files/msvc2017.tar is missing. This file can be created on a Windows 7 or 10 machine by downloading the 'Visual Studio Tools' installer."
     echo "here: https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2017"
@@ -84,5 +93,5 @@ if [ "${build_msvc}" != "0" ]; then
     exit 1
   fi
 
-  $podman_build -t godot-msvc:${img_version} -f Dockerfile.msvc . 2>&1 | tee logs/msvc.log
+  podman_build godot-msvc msvc
 fi

--- a/build.sh
+++ b/build.sh
@@ -8,8 +8,10 @@ if [ -z $podman ]; then
   exit 1
 fi
 
+platforms="linux,windows,web,android,osx,ios,msvc"
+
 if [ -z "$1" -o -z "$2" ]; then
-  echo "Usage: $0 <godot branch> <base distro>"
+  echo "Usage: $0 <godot branch> <base distro> [<platforms>]"
   echo
   echo "Example: $0 3.x f35"
   echo
@@ -19,6 +21,10 @@ if [ -z "$1" -o -z "$2" ]; then
   echo "base distro:"
   echo "        Informational, tracks the base Linux distro these containers are based on."
   echo
+  echo "(Optional) platforms:"
+  echo "        Comma-separated list of platforms."
+  echo "        Defaults to: $platforms"
+  echo
   echo "The resulting image version will be <godot branch>-<base distro>."
   exit 1
 fi
@@ -27,7 +33,14 @@ godot_branch=$1
 base_distro=$2
 img_version=$godot_branch-$base_distro
 files_root="$(cd dirname "$0"; pwd)/files"
-build_msvc=0
+
+if [ ! -z "$3" ]; then
+  case "$3" in
+    free) platforms="linux,windows,web,android";;
+    nonfree) platforms="osx,ios,msvc";;
+    *) platforms="$3";;
+  esac
+fi
 
 # Confirm settings
 echo "Docker image tag: ${img_version}"
@@ -57,36 +70,36 @@ podman_build() {
 
 podman_build export
 
-podman_build linux
-podman_build windows
+for platform in linux windows web android; do
+  if grep -q "$platform" <<< "$platforms"; then podman_build "$platform"; fi
+done
 
-podman_build web
-podman_build android
+if grep -q osx <<< "$platforms" || grep -q ios <<< "$platforms"; then
+  XCODE_SDK=14.1
+  OSX_SDK=13.0
+  IOS_SDK=16.1
+  if [ ! -e "${files_root}"/MacOSX${OSX_SDK}.sdk.tar.xz ] || [ ! -e "${files_root}"/iPhoneOS${IOS_SDK}.sdk.tar.xz ] || [ ! -e "${files_root}"/iPhoneSimulator${IOS_SDK}.sdk.tar.xz ]; then
+    if [ ! -e "${files_root}"/Xcode_${XCODE_SDK}.xip ]; then
+      echo "files/Xcode_${XCODE_SDK}.xip is required. It can be downloaded from https://developer.apple.com/download/more/ with a valid apple ID."
+      exit 1
+    fi
 
-XCODE_SDK=14.1
-OSX_SDK=13.0
-IOS_SDK=16.1
-if [ ! -e "${files_root}"/MacOSX${OSX_SDK}.sdk.tar.xz ] || [ ! -e "${files_root}"/iPhoneOS${IOS_SDK}.sdk.tar.xz ] || [ ! -e "${files_root}"/iPhoneSimulator${IOS_SDK}.sdk.tar.xz ]; then
-  if [ ! -e "${files_root}"/Xcode_${XCODE_SDK}.xip ]; then
-    echo "files/Xcode_${XCODE_SDK}.xip is required. It can be downloaded from https://developer.apple.com/download/more/ with a valid apple ID."
-    exit 1
+    echo "Building OSX and iOS SDK packages. This will take a while"
+    podman_build xcode
+    $podman run -it --rm \
+      -v "${files_root}":/root/files:z \
+      -e XCODE_SDKV="${XCODE_SDK}" \
+      -e OSX_SDKV="${OSX_SDK}" \
+      -e IOS_SDKV="${IOS_SDK}" \
+      godot-xcode:${img_version} \
+      2>&1 | tee logs/xcode_packer.log
   fi
 
-  echo "Building OSX and iOS SDK packages. This will take a while"
-  podman_build xcode
-  $podman run -it --rm \
-    -v "${files_root}":/root/files:z \
-    -e XCODE_SDKV="${XCODE_SDK}" \
-    -e OSX_SDKV="${OSX_SDK}" \
-    -e IOS_SDKV="${IOS_SDK}" \
-    godot-xcode:${img_version} \
-    2>&1 | tee logs/xcode_packer.log
+  podman_build osx
+  podman_build ios
 fi
 
-podman_build osx
-podman_build ios
-
-if [ "${build_msvc}" != "0" ]; then
+if grep -q msvc <<< "$platforms"; then
   if [ ! -e "${files_root}"/msvc2017.tar ]; then
     echo
     echo "files/msvc2017.tar is missing. This file can be created on a Windows 7 or 10 machine by downloading the 'Visual Studio Tools' installer."

--- a/build.sh
+++ b/build.sh
@@ -57,8 +57,8 @@ $podman_build -t godot-android:${img_version} -f Dockerfile.android . 2>&1 | tee
 XCODE_SDK=14.1
 OSX_SDK=13.0
 IOS_SDK=16.1
-if [ ! -e files/MacOSX${OSX_SDK}.sdk.tar.xz ] || [ ! -e files/iPhoneOS${IOS_SDK}.sdk.tar.xz ] || [ ! -e files/iPhoneSimulator${IOS_SDK}.sdk.tar.xz ]; then
-  if [ ! -e files/Xcode_${XCODE_SDK}.xip ]; then
+if [ ! -e ${files_root}/MacOSX${OSX_SDK}.sdk.tar.xz ] || [ ! -e ${files_root}/iPhoneOS${IOS_SDK}.sdk.tar.xz ] || [ ! -e ${files_root}/iPhoneSimulator${IOS_SDK}.sdk.tar.xz ]; then
+  if [ ! -e ${files_root}/Xcode_${XCODE_SDK}.xip ]; then
     echo "files/Xcode_${XCODE_SDK}.xip is required. It can be downloaded from https://developer.apple.com/download/more/ with a valid apple ID."
     exit 1
   fi
@@ -72,7 +72,7 @@ $podman_build -t godot-osx:${img_version} -f Dockerfile.osx . 2>&1 | tee logs/os
 $podman_build -t godot-ios:${img_version} -f Dockerfile.ios . 2>&1 | tee logs/ios.log
 
 if [ "${build_msvc}" != "0" ]; then
-  if [ ! -e files/msvc2017.tar ]; then
+  if [ ! -e ${files_root}/msvc2017.tar ]; then
     echo
     echo "files/msvc2017.tar is missing. This file can be created on a Windows 7 or 10 machine by downloading the 'Visual Studio Tools' installer."
     echo "here: https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2017"

--- a/build.sh
+++ b/build.sh
@@ -26,7 +26,7 @@ fi
 godot_branch=$1
 base_distro=$2
 img_version=$godot_branch-$base_distro
-files_root=$(pwd)/files
+files_root="$(cd dirname "$0"; pwd)/files"
 build_msvc=0
 
 # Confirm settings

--- a/build.sh
+++ b/build.sh
@@ -50,18 +50,18 @@ podman_build() {
   "$podman" build \
   --build-arg img_version=${img_version} \
   -v "${files_root}":/root/files:z \
-  -t "$1:${img_version}" \
-  -f Dockerfile."$2" . \
-  2>&1 | tee logs/"$2".log
+  -t godot-"$1:${img_version}" \
+  -f Dockerfile."$1" . \
+  2>&1 | tee logs/"$1".log
 }
 
-podman_build godot-export export
+podman_build export
 
-podman_build godot-linux linux
-podman_build godot-windows windows
+podman_build linux
+podman_build windows
 
-podman_build godot-web web
-podman_build godot-android android
+podman_build web
+podman_build android
 
 XCODE_SDK=14.1
 OSX_SDK=13.0
@@ -73,12 +73,18 @@ if [ ! -e "${files_root}"/MacOSX${OSX_SDK}.sdk.tar.xz ] || [ ! -e "${files_root}
   fi
 
   echo "Building OSX and iOS SDK packages. This will take a while"
-  podman_build godot-xcode-packer xcode
-  $podman run -it --rm -v "${files_root}":/root/files:z -e XCODE_SDKV="${XCODE_SDK}" -e OSX_SDKV="${OSX_SDK}" -e IOS_SDKV="${IOS_SDK}" godot-xcode-packer:${img_version} 2>&1 | tee logs/xcode_packer.log
+  podman_build xcode
+  $podman run -it --rm \
+    -v "${files_root}":/root/files:z \
+    -e XCODE_SDKV="${XCODE_SDK}" \
+    -e OSX_SDKV="${OSX_SDK}" \
+    -e IOS_SDKV="${IOS_SDK}" \
+    godot-xcode:${img_version} \
+    2>&1 | tee logs/xcode_packer.log
 fi
 
-podman_build godot-osx osx
-podman_build godot-ios ios
+podman_build osx
+podman_build ios
 
 if [ "${build_msvc}" != "0" ]; then
   if [ ! -e "${files_root}"/msvc2017.tar ]; then
@@ -93,5 +99,5 @@ if [ "${build_msvc}" != "0" ]; then
     exit 1
   fi
 
-  podman_build godot-msvc msvc
+  podman_build msvc
 fi

--- a/upload.sh
+++ b/upload.sh
@@ -23,7 +23,7 @@ $podman push godot-export:${img_version} ${registry}/godot/export
 $podman push godot-linux:${img_version} ${registry}/godot/linux
 $podman push godot-windows:${img_version} ${registry}/godot/windows
 $podman push godot-web:${img_version} ${registry}/godot/web
-$podman push godot-xcode-packer:${img_version} ${registry}/godot/xcode-packer
+$podman push godot-xcode:${img_version} ${registry}/godot/xcode
 
 $podman push godot-android:${img_version} ${registry}/godot-private/android
 $podman push godot-ios:${img_version} ${registry}/godot-private/ios


### PR DESCRIPTION
This PR is based on #121.

Instead of building all the images when `./build.sh` is executed, this PR allows specifying a subset through a comma-separated list.