### PR TITLE
Update to Fedora 39, update all toolchains

### DIFF
--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -6,13 +6,13 @@ ENV ANDROID_NDK_VERSION=23.2.8568313
 ENV ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk/${ANDROID_NDK_VERSION}
 
 RUN dnf -y install --setopt=install_weak_deps=False \
-      java-11-openjdk-devel ncurses-compat-libs && \
+      java-17-openjdk-devel ncurses-compat-libs && \
     mkdir -p sdk && cd sdk && \
-    export CMDLINETOOLS=commandlinetools-linux-8512546_latest.zip && \
+    export CMDLINETOOLS=commandlinetools-linux-10406996_latest.zip && \
     curl -LO https://dl.google.com/android/repository/${CMDLINETOOLS} && \
     unzip ${CMDLINETOOLS} && \
     rm ${CMDLINETOOLS} && \
     yes | cmdline-tools/bin/sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" --licenses && \
-    cmdline-tools/bin/sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" "ndk;${ANDROID_NDK_VERSION}" 'cmdline-tools;latest' 'build-tools;32.0.0' 'platforms;android-32' 'cmake;3.18.1'
+    cmdline-tools/bin/sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" "ndk;${ANDROID_NDK_VERSION}" 'cmdline-tools;latest' 'build-tools;33.0.2' 'platforms;android-33' 'cmake;3.22.1'
 
 CMD /bin/bash

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM fedora:36
+FROM fedora:39
 
 WORKDIR /root
 
@@ -6,8 +6,8 @@ ENV DOTNET_NOLOGO=1
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 
 RUN dnf -y install --setopt=install_weak_deps=False \
-      bash bzip2 curl file findutils git make nano patch pkgconfig python3-pip unzip which xz \
+      bash bzip2 curl file findutils gettext git make nano patch pkgconfig python3-pip unzip which xz \
       dotnet-sdk-6.0 && \
-    pip install scons==4.4.0
+    pip install scons==4.5.2
 
 CMD /bin/bash

--- a/Dockerfile.ios
+++ b/Dockerfile.ios
@@ -1,30 +1,31 @@
 ARG img_version
 FROM godot-osx:${img_version}
 
-ENV IOS_SDK=16.1
+ENV IOS_SDK=17.0
 
 RUN dnf -y install --setopt=install_weak_deps=False \
       automake autoconf gcc gcc-c++ gcc-objc gcc-objc++ cmake libicu-devel libtool libxml2-devel openssl-devel perl python yasm && \
-    git clone --progress https://github.com/tpoechtrager/cctools-port.git && \
+    git clone --progress https://github.com/tpoechtrager/cctools-port && \
     cd /root/cctools-port && \
-    git checkout 11c93763d7e7ce7305163341d08052374e4712de && \
+    git checkout 437ced391dbf14dce86f977ca050a750d5682f39 && \
+    curl -LO https://github.com/tpoechtrager/cctools-port/pull/136.patch && \
+    git apply 136.patch && \
     # arm64 device
     usage_examples/ios_toolchain/build.sh /root/files/iPhoneOS${IOS_SDK}.sdk.tar.xz arm64 && \
     mkdir -p /root/ioscross/arm64 && \
     mv usage_examples/ios_toolchain/target/* /root/ioscross/arm64 && \
     mkdir /root/ioscross/arm64/usr && \
     ln -s /root/ioscross/arm64/bin /root/ioscross/arm64/usr/bin && \
+    # Prepare for simulator builds
+    sed -i '/WRAPPER_SDKDIR/s/iPhoneOS/iPhoneSimulator/' usage_examples/ios_toolchain/build.sh && \
     # arm64 simulator
-    # Disabled for now as it doesn't work with cctools-port and current LLVM:
-    # Cf. https://github.com/tpoechtrager/cctools-port/issues/102
-    #sed -i 's/miphoneos-version-min/mios-simulator-version-min/g' usage_examples/ios_toolchain/wrapper.c && \
-    #usage_examples/ios_toolchain/build.sh /root/files/iPhoneSimulator${IOS_SDK}.sdk.tar.xz arm64 && \
-    #mkdir -p /root/ioscross/arm64_sim && \
-    #mv usage_examples/ios_toolchain/target/* /root/ioscross/arm64_sim && \
-    #mkdir /root/ioscross/arm64_sim/usr && \
-    #ln -s /root/ioscross/arm64_sim/bin /root/ioscross/arm64_sim/usr/bin && \
+    usage_examples/ios_toolchain/build.sh /root/files/iPhoneSimulator${IOS_SDK}.sdk.tar.xz arm64 && \
+    mkdir -p /root/ioscross/arm64_sim && \
+    mv usage_examples/ios_toolchain/target/* /root/ioscross/arm64_sim && \
+    mkdir /root/ioscross/arm64_sim/usr && \
+    ln -s /root/ioscross/arm64_sim/bin /root/ioscross/arm64_sim/usr/bin && \
     # x86_64 simulator
-    sed -i 's#^TRIPLE=.*#TRIPLE="x86_64-apple-darwin11"#' usage_examples/ios_toolchain/build.sh && \
+    sed -i 's/^TRIPLE=.*/TRIPLE="x86_64-apple-darwin11"/' usage_examples/ios_toolchain/build.sh && \
     usage_examples/ios_toolchain/build.sh /root/files/iPhoneSimulator${IOS_SDK}.sdk.tar.xz x86_64 && \
     mkdir -p /root/ioscross/x86_64_sim && \
     mv usage_examples/ios_toolchain/target/* /root/ioscross/x86_64_sim && \

--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -2,15 +2,17 @@ ARG img_version
 FROM godot-fedora:${img_version}
 
 RUN dnf -y install --setopt=install_weak_deps=False \
-      automake autoconf bzip2-devel cmake gcc gcc-c++ libicu-devel libtool libxml2-devel openssl-devel yasm \
-      clang llvm-devel && \
-    git clone --progress https://github.com/tpoechtrager/osxcross.git && \
+      automake autoconf bzip2-devel cmake gcc gcc-c++ libdispatch libicu-devel libtool \
+      libxml2-devel openssl-devel uuid-devel yasm && \
+    git clone --progress https://github.com/tpoechtrager/osxcross && \
     cd /root/osxcross && \
-    git checkout 50e86ebca7d14372febd0af8cd098705049161b9 && \
-    ln -s /root/files/MacOSX13.0.sdk.tar.xz /root/osxcross/tarballs && \
+    git checkout 5e1b71fcceb23952f3229995edca1b6231525b5b && \
+    ln -s /root/files/MacOSX14.0.sdk.tar.xz /root/osxcross/tarballs && \
     export UNATTENDED=1 && \
-    # Custom build Clang if the Fedora version doesn't match the Xcode SDK.
-    #CLANG_VERSION=14.0.6 ENABLE_CLANG_INSTALL=1 INSTALLPREFIX=/usr ./build_clang.sh && \
+    # Custom build Apple Clang to ensure compatibility.
+    # Find the equivalent LLVM version for the SDK from:
+    # https://en.wikipedia.org/wiki/Xcode#Toolchain_versions
+    CLANG_VERSION=16.0.0 ENABLE_CLANG_INSTALL=1 INSTALLPREFIX=/usr ./build_apple_clang.sh && \
     ./build.sh && \
     ./build_compiler_rt.sh && \
     rm -rf /root/osxcross/build

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,7 +1,7 @@
 ARG img_version
 FROM godot-fedora:${img_version}
 
-ENV EMSCRIPTEN_VERSION=3.1.18
+ENV EMSCRIPTEN_VERSION=3.1.39
 
 RUN git clone --branch ${EMSCRIPTEN_VERSION} --progress https://github.com/emscripten-core/emsdk && \
     emsdk/emsdk install ${EMSCRIPTEN_VERSION} && \

--- a/Dockerfile.xcode
+++ b/Dockerfile.xcode
@@ -5,7 +5,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
       clang xar xar-devel xz-devel cpio && \
     git clone --progress https://github.com/nrosenstein-stuff/pbzx && \
     cd pbzx && \
-    git checkout 2a4d7c3300c826d918def713a24d25c237c8ed53 && \
+    git checkout bf536e167f2e514866f91d7baa0df1dff5a13711 && \
     clang -O3 -llzma -lxar -I /usr/local/include pbzx.c -o pbzx
 
 ENV XCODE_SDKV=
@@ -18,12 +18,6 @@ CMD mkdir -p /root/xcode && \
     /root/pbzx/pbzx -n Content | cpio -i && \
     export OSX_SDK=MacOSX${OSX_SDKV}.sdk && \
     cp -r Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk /tmp/${OSX_SDK} && \
-    mkdir -p /tmp/${OSX_SDK}/usr/include/c++ && \
-    cp -r Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1 /tmp/${OSX_SDK}/usr/include/c++/ && \
-    mkdir -p mkdir -p /tmp/${OSX_SDK}/usr/share/man && \
-    cp -rf Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/share/man/man1 \
-           Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/share/man/man3 \
-           Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/share/man/man5 /tmp/${OSX_SDK}/usr/share/man/ && \
     cd /tmp && \
     tar -cJf /root/files/${OSX_SDK}.tar.xz ${OSX_SDK} && \
     rm -rf ${OSX_SDK} && \
@@ -31,15 +25,11 @@ CMD mkdir -p /root/xcode && \
     export IOS_SDK=iPhoneOS${IOS_SDKV}.sdk && \
     export IOS_SIMULATOR_SDK=iPhoneSimulator${IOS_SDKV}.sdk && \
     cp -r Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk /tmp/${IOS_SDK} && \
-    mkdir -p /tmp/${IOS_SDK}/usr/include/c++ && \
-    cp -r Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1 /tmp/${IOS_SDK}/usr/include/c++/ && \
     cd /tmp && \
     tar -cJf /root/files/${IOS_SDK}.tar.xz ${IOS_SDK} && \
     rm -rf ${IOS_SDK} && \
     cd /root/xcode && \
-    cp -r Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk /tmp/${IOS_SDK} && \
-    mkdir -p /tmp/${IOS_SDK}/usr/include/c++ && \
-    cp -r Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1 /tmp/${IOS_SDK}/usr/include/c++/ && \
+    cp -r Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk /tmp/${IOS_SIMULATOR_SDK} && \
     cd /tmp && \
-    tar -cJf /root/files/${IOS_SIMULATOR_SDK}.tar.xz ${IOS_SDK} && \
-    rm -rf ${IOS_SDK}
+    tar -cJf /root/files/${IOS_SIMULATOR_SDK}.tar.xz ${IOS_SIMULATOR_SDK} && \
+    rm -rf ${IOS_SIMULATOR_SDK}

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ The `build.sh` script included is used to build the containers themselves.
 
 The two arguments can take any value and are meant to convey what Godot branch
 you are building for (e.g. `4.x`) and what Linux distribution the `Dockerfile.base`
-is based on (e.g. `f36` for Fedora 36).
+is based on (e.g. `f39` for Fedora 39).
 
 Run the command using:
 
-    ./build.sh 4.x f36
+    ./build.sh 4.x f39
 
-The above will generate images using the tag '4.x-f36'.
+The above will generate images using the tag '4.x-f39'.
 You can then specify it in the `build.sh` of
 [godot-build-scripts](https://github.com/godotengine/godot-build-scripts).
 
@@ -53,10 +53,10 @@ You can then specify it in the `build.sh` of
 If you don't need to build all versions or you want to try with a single target OS first,
 you can comment out the corresponding lines from the script:
 
-    $podman_build -t godot-linux:${img_version} -f Dockerfile.linux . 2>&1 | tee logs/linux.log
-    $podman_build -t godot-windows:${img_version} -f Dockerfile.windows . 2>&1 | tee logs/windows.log
-    $podman_build -t godot-web:${img_version} -f Dockerfile.web . 2>&1 | tee logs/web.log
-    $podman_build -t godot-android:${img_version} -f Dockerfile.android . 2>&1 | tee logs/android.log
+    podman_build linux
+    podman_build windows
+    podman_build web
+    podman_build android
     ...
 
 
@@ -64,28 +64,28 @@ you can comment out the corresponding lines from the script:
 
 These are the expected container image sizes, so you can plan your disk usage in advance:
 
-    REPOSITORY                                       TAG                        SIZE
-    localhost/godot-fedora                           4.x-f36                    1.06 GB
-    localhost/godot-linux                            4.x-f36                    2.07 GB
-    localhost/godot-windows                          4.x-f36                    1.81 GB
-    localhost/godot-web                              4.x-f36                    2.2 GB
-    localhost/godot-android                          4.x-f36                    4.24 GB
-    localhost/godot-osx                              4.x-f36                    4.56 GB
-    localhost/godot-ios                              4.x-f36                    5.01 GB
+    REPOSITORY                         TAG                SIZE
+    localhost/godot-fedora             4.x-f39            1.08 GB
+    localhost/godot-linux              4.x-f39            2.10 GB
+    localhost/godot-windows            4.x-f39            1.89 GB
+    localhost/godot-web                4.x-f39            2.24 GB
+    localhost/godot-android            4.x-f39            3.67 GB
+    localhost/godot-osx                4.x-f39            4.70 GB
+    localhost/godot-ios                4.x-f39            5.30 GB
 
 In addition to this, generating containers will also require some host disk space
-(around 10 GB) for the dependencies (Xcode).
+(up to 10 GB) for the dependencies (Xcode).
 
 
 ## Toolchains
 
-These are the toolchains currently in use for Godot 4.0 and later:
+These are the toolchains currently in use for Godot 4.2 and later:
 
-- Base image: Fedora 36
-- SCons: 4.4.0
+- Base image: Fedora 39
+- SCons: 4.5.2
 - Linux: GCC 10.2.0 built against glibc 2.19, binutils 2.35.1, from our own [Linux SDK](https://github.com/godotengine/buildroot)
-- Windows: MinGW 9.0.0, GCC 11.2.0, binutils 2.37
-- Web: Emscripten 3.1.18
-- Android: Android NDK 23.2.8568313, build-tools 32.0.0, platform android-32, CMake 3.18.1
-- macOS: Xcode 13.3.1 with LLVM Clang 13.0.1, MacOSX SDK 12.3
-- iOS: Xcode 13.3.1 with LLVM Clang 13.0.1, iPhoneOS SDK 15.4
+- Windows: MinGW 11.0.0, GCC 13.2.1, binutils 2.40
+- Web: Emscripten 3.1.39
+- Android: Android NDK 23.2.8568313, build-tools 33.0.2, platform android-33, CMake 3.22.1, JDK 17
+- macOS: Xcode 15.0 with Apple Clang (LLVM 16.0.0), MacOSX SDK 14.0
+- iOS: Xcode 15.0 with Apple Clang (LLVM 16.0.0), iPhoneOS SDK 17.0

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ source $basedir/setup.sh
 if [ -z "$1" -o -z "$2" ]; then
   echo "Usage: $0 <godot branch> <base distro>"
   echo
-  echo "Example: $0 3.x f35"
+  echo "Example: $0 4.x f39"
   echo
   echo "godot branch:"
   echo "        Informational, tracks the Godot branch these containers are intended for."
@@ -58,9 +58,9 @@ podman_build windows
 podman_build web
 podman_build android
 
-XCODE_SDK=14.1
-OSX_SDK=13.0
-IOS_SDK=16.1
+XCODE_SDK=15
+OSX_SDK=14.0
+IOS_SDK=17.0
 if [ ! -e "${files_root}"/MacOSX${OSX_SDK}.sdk.tar.xz ] || [ ! -e "${files_root}"/iPhoneOS${IOS_SDK}.sdk.tar.xz ] || [ ! -e "${files_root}"/iPhoneSimulator${IOS_SDK}.sdk.tar.xz ]; then
   if [ ! -e "${files_root}"/Xcode_${XCODE_SDK}.xip ]; then
     echo "files/Xcode_${XCODE_SDK}.xip is required. It can be downloaded from https://developer.apple.com/download/more/ with a valid apple ID."


### PR DESCRIPTION
Update to Fedora 39, update all toolchains

- Base image: Fedora 39
- SCons: 4.5.2
- Linux: GCC 10.2.0 built against glibc 2.19, binutils 2.35.1
- Windows: MinGW 11.0.0, GCC 13.2.1, binutils 2.40
- Web: Emscripten 3.1.39
- Android: Android NDK 23.2.8568313, build-tools 33.0.2, platform android-33, CMake 3.22.1, JDK 17
- macOS: Xcode 15.0 with Apple Clang (LLVM 16.0.0), MacOSX SDK 14.0
- iOS: Xcode 15.0 with Apple Clang (LLVM 16.0.0), iPhoneOS SDK 17.0

Switches macOS/iOS builds to use Apple Clang, to maximize compatibility with upstream Xcode. ~This enables us to build the arm64 simulator for iOS.~ (Still doesn't work.)

Also add gettext which is needed by Godot build scripts to compile PO files to MO.

---

Draft for now as I haven't tested building Godot with those yet. I expect at least for Android we need some adjustments in upstream build scripts to use those toolchains (CC @m4gr3d).