### PR TITLE
Change "/bin/bash" to "/usr/bin/env bash" in shell files

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 basedir=$(cd $(dirname "$0"); pwd)
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/upload.sh
+++ b/upload.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source $(dirname "$0")/setup.sh
 


### PR DESCRIPTION
On my NixOS machine, there is no "/bin/bash". my bash executable located at "/run/current-system/sw/bin/bash", so ./build ends with error. To avoid that, I changed "/bin/bash" to "/usr/bin/env bash". As far as I know, "/usr/bin/env" exists on every major distro, and basically returns path to shell, in our case it's bash. With this change, script will run on any distro, it doesn't matter where bash executable is located.