### PR TITLE
Linux: Update buildroot SDK to 2023.08, add arm64 SDK

### DIFF
--- a/Dockerfile.linux
+++ b/Dockerfile.linux
@@ -2,31 +2,33 @@ ARG img_version
 FROM godot-fedora:${img_version}
 
 ENV GODOT_SDK_LINUX_X86_64=/root/x86_64-godot-linux-gnu_sdk-buildroot
-ENV GODOT_SDK_LINUX_X86=/root/i686-godot-linux-gnu_sdk-buildroot
-ENV GODOT_SDK_LINUX_ARMHF=/root/arm-godot-linux-gnueabihf_sdk-buildroot
+ENV GODOT_SDK_LINUX_X86_32=/root/i686-godot-linux-gnu_sdk-buildroot
+ENV GODOT_SDK_LINUX_ARM64=/root/aarch64-godot-linux-gnu_sdk-buildroot
+ENV GODOT_SDK_LINUX_ARM32=/root/arm-godot-linux-gnueabihf_sdk-buildroot
 ENV BASE_PATH=${PATH}
 
-RUN dnf -y install --setopt=install_weak_deps=False \
-      libxcrypt-compat yasm && \
-    curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2021-02-11/x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
+RUN curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2023-11-01/x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     tar xf x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     rm -f x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     cd x86_64-godot-linux-gnu_sdk-buildroot && \
     ./relocate-sdk.sh && \
-    rm -f bin/{aclocal*,auto*,libtool*,m4} && \
     cd /root && \
-    curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2021-02-11/arm-godot-linux-gnueabihf_sdk-buildroot.tar.bz2 && \
-    tar xf arm-godot-linux-gnueabihf_sdk-buildroot.tar.bz2 && \
-    rm -f arm-godot-linux-gnueabihf_sdk-buildroot.tar.bz2 && \
-    cd arm-godot-linux-gnueabihf_sdk-buildroot && \
-    ./relocate-sdk.sh && \
-    rm -f bin/{aclocal*,auto*,libtool*,m4} && \
-    cd /root && \
-    curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2021-02-11/i686-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
+    curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2023-11-01/i686-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     tar xf i686-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     rm -f i686-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     cd i686-godot-linux-gnu_sdk-buildroot && \
     ./relocate-sdk.sh && \
-    rm -f bin/{aclocal*,auto*,libtool*,m4}
+    cd /root && \
+    curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2023-11-01/aarch64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
+    tar xf aarch64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
+    rm -f aarch64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
+    cd aarch64-godot-linux-gnu_sdk-buildroot && \
+    ./relocate-sdk.sh && \
+    cd /root && \
+    curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2023-11-01/arm-godot-linux-gnueabihf_sdk-buildroot.tar.bz2 && \
+    tar xf arm-godot-linux-gnueabihf_sdk-buildroot.tar.bz2 && \
+    rm -f arm-godot-linux-gnueabihf_sdk-buildroot.tar.bz2 && \
+    cd arm-godot-linux-gnueabihf_sdk-buildroot && \
+    ./relocate-sdk.sh
 
 CMD /bin/bash

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ These are the expected container image sizes, so you can plan your disk usage in
 
     REPOSITORY                         TAG                SIZE
     localhost/godot-fedora             4.x-f39            1.08 GB
-    localhost/godot-linux              4.x-f39            2.10 GB
+    localhost/godot-linux              4.x-f39            2.86 GB
     localhost/godot-windows            4.x-f39            1.89 GB
     localhost/godot-web                4.x-f39            2.24 GB
     localhost/godot-android            4.x-f39            3.67 GB
@@ -83,7 +83,7 @@ These are the toolchains currently in use for Godot 4.2 and later:
 
 - Base image: Fedora 39
 - SCons: 4.5.2
-- Linux: GCC 10.2.0 built against glibc 2.19, binutils 2.35.1, from our own [Linux SDK](https://github.com/godotengine/buildroot)
+- Linux: GCC 13.2.0 built against glibc 2.28, binutils 2.40, from our own [Linux SDK](https://github.com/godotengine/buildroot)
 - Windows: MinGW 11.0.0, GCC 13.2.1, binutils 2.40
 - Web: Emscripten 3.1.39
 - Android: Android NDK 23.2.8568313, build-tools 33.0.2, platform android-33, CMake 3.22.1, JDK 17


### PR DESCRIPTION
Provides GCC 13.2.0 built against glibc 2.28, binutils 2.40.