### PR TITLE
[3.x] Update to Fedora 39, newer toolchains, add Linux arm64

### DIFF
--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -7,16 +7,15 @@ ENV ANDROID_SDK_ROOT=/root/sdk
 ENV ANDROID_NDK_VERSION=23.2.8568313
 ENV ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk/${ANDROID_NDK_VERSION}
 
-RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
-    dnf -y install --setopt=install_weak_deps=False \
-      java-11-openjdk-devel ncurses-compat-libs && \
+RUN dnf -y install --setopt=install_weak_deps=False \
+      java-17-openjdk-devel ncurses-compat-libs && \
     mkdir -p sdk && cd sdk && \
-    export CMDLINETOOLS=commandlinetools-linux-8512546_latest.zip && \
+    export CMDLINETOOLS=commandlinetools-linux-10406996_latest.zip && \
     curl -LO https://dl.google.com/android/repository/${CMDLINETOOLS} && \
     unzip ${CMDLINETOOLS} && \
     rm ${CMDLINETOOLS} && \
     yes | cmdline-tools/bin/sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" --licenses && \
-    cmdline-tools/bin/sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" "ndk;${ANDROID_NDK_VERSION}" 'cmdline-tools;latest' 'build-tools;32.0.0' 'platforms;android-32' 'cmake;3.18.1'
+    cmdline-tools/bin/sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" "ndk;${ANDROID_NDK_VERSION}" 'cmdline-tools;latest' 'build-tools;33.0.2' 'platforms;android-33' 'cmake;3.22.1'
 
 RUN cp -a /root/files/${mono_version} /root && \
     export MONO_SOURCE_ROOT=/root/${mono_version} && \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,9 +1,9 @@
-FROM fedora:36
+FROM fedora:39
 
 WORKDIR /root
 
 RUN dnf -y install --setopt=install_weak_deps=False \
-      bash bzip2 curl file findutils git make nano patch pkgconfig python3-pip unzip which xz && \
-    pip install scons==4.3.0
+      bash bzip2 curl file findutils gettext git make nano patch pkgconfig python3-pip unzip which xz && \
+    pip install scons==4.5.2
 
 CMD /bin/bash

--- a/Dockerfile.ios
+++ b/Dockerfile.ios
@@ -3,30 +3,31 @@ FROM godot-osx:${img_version}
 
 ARG mono_version
 
-ENV IOS_SDK=15.4
+ENV IOS_SDK=17.0
 
 RUN dnf -y install --setopt=install_weak_deps=False \
       automake autoconf gcc gcc-c++ gcc-objc gcc-objc++ cmake libicu-devel libtool libxml2-devel openssl-devel perl python yasm && \
-    git clone --progress https://github.com/tpoechtrager/cctools-port.git && \
+    git clone --progress https://github.com/tpoechtrager/cctools-port && \
     cd /root/cctools-port && \
-    git checkout 04663295d0425abfac90a42440a7ec02d7155fea && \
+    git checkout 437ced391dbf14dce86f977ca050a750d5682f39 && \
+    curl -LO https://github.com/tpoechtrager/cctools-port/pull/136.patch && \
+    git apply 136.patch && \
     # arm64 device
     usage_examples/ios_toolchain/build.sh /root/files/iPhoneOS${IOS_SDK}.sdk.tar.xz arm64 && \
     mkdir -p /root/ioscross/arm64 && \
     mv usage_examples/ios_toolchain/target/* /root/ioscross/arm64 && \
     mkdir /root/ioscross/arm64/usr && \
     ln -s /root/ioscross/arm64/bin /root/ioscross/arm64/usr/bin && \
+    # Prepare for simulator builds
+    sed -i '/WRAPPER_SDKDIR/s/iPhoneOS/iPhoneSimulator/' usage_examples/ios_toolchain/build.sh && \
     # arm64 simulator
-    # Disabled for now as it doesn't work with cctools-port and current LLVM:
-    # Cf. https://github.com/tpoechtrager/cctools-port/issues/102
-    #sed -i 's/miphoneos-version-min/mios-simulator-version-min/g' usage_examples/ios_toolchain/wrapper.c && \
-    #usage_examples/ios_toolchain/build.sh /root/files/iPhoneSimulator${IOS_SDK}.sdk.tar.xz arm64 && \
-    #mkdir -p /root/ioscross/arm64_sim && \
-    #mv usage_examples/ios_toolchain/target/* /root/ioscross/arm64_sim && \
-    #mkdir /root/ioscross/arm64_sim/usr && \
-    #ln -s /root/ioscross/arm64_sim/bin /root/ioscross/arm64_sim/usr/bin && \
+    usage_examples/ios_toolchain/build.sh /root/files/iPhoneSimulator${IOS_SDK}.sdk.tar.xz arm64 && \
+    mkdir -p /root/ioscross/arm64_sim && \
+    mv usage_examples/ios_toolchain/target/* /root/ioscross/arm64_sim && \
+    mkdir /root/ioscross/arm64_sim/usr && \
+    ln -s /root/ioscross/arm64_sim/bin /root/ioscross/arm64_sim/usr/bin && \
     # x86_64 simulator
-    sed -i 's#^TRIPLE=.*#TRIPLE="x86_64-apple-darwin11"#' usage_examples/ios_toolchain/build.sh && \
+    sed -i 's/^TRIPLE=.*/TRIPLE="x86_64-apple-darwin11"/' usage_examples/ios_toolchain/build.sh && \
     usage_examples/ios_toolchain/build.sh /root/files/iPhoneSimulator${IOS_SDK}.sdk.tar.xz x86_64 && \
     mkdir -p /root/ioscross/x86_64_sim && \
     mv usage_examples/ios_toolchain/target/* /root/ioscross/x86_64_sim && \
@@ -39,19 +40,18 @@ ENV OSXCROSS_IOS=not_nothing
 ENV IOSCROSS_ROOT=/root/ioscross
 ENV PATH="/root/ioscross/arm64/bin:/root/ioscross/arm64_sim/bin:/root/ioscross/x86_64_sim/bin:${PATH}"
 
-RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
-    cp -a /root/files/${mono_version} /root && \
+RUN cp -a /root/files/${mono_version} /root && \
     cd /root/${mono_version} && \
     cd godot-mono-builds && \
     export MONO_SOURCE_ROOT=/root/${mono_version} && \
     python3 ios.py configure -j --target=arm64 --ios-version-min 10.0 --osx-toolchain ${OSXCROSS_ROOT} \
       --ios-toolchain ${IOSCROSS_ROOT}/arm64 --ios-sdk ${IOSCROSS_ROOT}/arm64/SDK/iPhoneOS${IOS_SDK}.sdk && \
     python3 ios.py make -j --target=arm64 && \
-    #python3 ios.py configure -j --target=arm64-sim --ios-version-min 10.0 --osx-toolchain ${OSXCROSS_ROOT} \
-    #  --ios-toolchain ${IOSCROSS_ROOT}/arm64_sim --ios-sdk ${IOSCROSS_ROOT}/arm64_sim/SDK/iPhoneOS${IOS_SDK}.sdk && \
-    #python3 ios.py make -j --target=arm64-sim && \
+    python3 ios.py configure -j --target=arm64-sim --ios-version-min 10.0 --osx-toolchain ${OSXCROSS_ROOT} \
+      --ios-toolchain ${IOSCROSS_ROOT}/arm64_sim --ios-sdk ${IOSCROSS_ROOT}/arm64_sim/SDK/iPhoneSimulator${IOS_SDK}.sdk && \
+    python3 ios.py make -j --target=arm64-sim && \
     python3 ios.py configure -j --target=x86_64 --ios-version-min 10.0 --osx-toolchain ${OSXCROSS_ROOT} \
-      --ios-toolchain ${IOSCROSS_ROOT}/x86_64_sim --ios-sdk ${IOSCROSS_ROOT}/x86_64_sim/SDK/iPhoneOS${IOS_SDK}.sdk && \
+      --ios-toolchain ${IOSCROSS_ROOT}/x86_64_sim --ios-sdk ${IOSCROSS_ROOT}/x86_64_sim/SDK/iPhoneSimulator${IOS_SDK}.sdk && \
     python3 ios.py make -j --target=x86_64 && \
     python3 bcl.py make -j --product=ios && \
     # TODO: Enable once godot-mono-builds supports osxcross for the cross-compiler.
@@ -63,7 +63,7 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
 
 # Until we can build the cross-compiler, we include a pre-made build in the container.
 RUN mkdir -p /root/aot-compilers/iphone-arm64 && \
-    curl -LO https://github.com/godotengine/godot-mono-builds/releases/download/release-8767196/ios-cross-arm64.zip && \
+    curl -LO https://github.com/godotengine/godot-mono-builds/releases/download/release-4912f62/ios-cross-arm64.zip && \
     dnf -y install --setopt=install_weak_deps=False p7zip && \
     7za e ios-cross-arm64.zip ios-cross-arm64-release/bin/aarch64-apple-darwin-mono-sgen -o/root/aot-compilers/iphone-arm64 && \
     rm ios-cross-arm64.zip

--- a/Dockerfile.javascript
+++ b/Dockerfile.javascript
@@ -3,15 +3,10 @@ FROM godot-mono:${img_version}
 
 ARG mono_version
 
-ENV EMSCRIPTEN_CLASSICAL=3.1.14
+ENV EMSCRIPTEN_CLASSICAL=3.1.39
 ENV EMSCRIPTEN_MONO=1.39.9
 
-RUN if [ -z "${mono_version}" ]; then printf "\n\nArgument mono_version is mandatory!\n\n"; exit 1; fi && \
-    # We need to downgrade to autoconf 2.69 from F35 as autoconf 2.71 from F36 breaks `--host wasm32`.
-    dnf -y install --setopt=install_weak_deps=False \
-      https://kojipkgs.fedoraproject.org//packages/autoconf/2.69/37.fc35/noarch/autoconf-2.69-37.fc35.noarch.rpm \
-      https://kojipkgs.fedoraproject.org//packages/automake/1.16.2/5.fc35/noarch/automake-1.16.2-5.fc35.noarch.rpm && \
-    git clone --branch ${EMSCRIPTEN_CLASSICAL} --progress https://github.com/emscripten-core/emsdk emsdk_${EMSCRIPTEN_CLASSICAL} && \
+RUN git clone --branch ${EMSCRIPTEN_CLASSICAL} --progress https://github.com/emscripten-core/emsdk emsdk_${EMSCRIPTEN_CLASSICAL} && \
     cp -r emsdk_${EMSCRIPTEN_CLASSICAL} emsdk_${EMSCRIPTEN_MONO} && \
     emsdk_${EMSCRIPTEN_CLASSICAL}/emsdk install ${EMSCRIPTEN_CLASSICAL} && \
     emsdk_${EMSCRIPTEN_CLASSICAL}/emsdk activate ${EMSCRIPTEN_CLASSICAL} && \

--- a/Dockerfile.linux
+++ b/Dockerfile.linux
@@ -4,31 +4,38 @@ FROM godot-mono:${img_version}
 ARG mono_version
 
 ENV GODOT_SDK_LINUX_X86_64=/root/x86_64-godot-linux-gnu_sdk-buildroot
-ENV GODOT_SDK_LINUX_X86=/root/i686-godot-linux-gnu_sdk-buildroot
-ENV GODOT_SDK_LINUX_ARMHF=/root/arm-godot-linux-gnueabihf_sdk-buildroot
+ENV GODOT_SDK_LINUX_X86_32=/root/i686-godot-linux-gnu_sdk-buildroot
+ENV GODOT_SDK_LINUX_ARM64=/root/aarch64-godot-linux-gnu_sdk-buildroot
+ENV GODOT_SDK_LINUX_ARM32=/root/arm-godot-linux-gnueabihf_sdk-buildroot
 ENV BASE_PATH=${PATH}
 
-RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
-    dnf -y install --setopt=install_weak_deps=False \
+RUN dnf -y install --setopt=install_weak_deps=False \
       libxcrypt-compat yasm && \
-    curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2021-02-11/x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
+    curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2023-12-11/x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     tar xf x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     rm -f x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     cd x86_64-godot-linux-gnu_sdk-buildroot && \
     ./relocate-sdk.sh && \
     rm -f bin/{aclocal*,auto*,libtool*,m4} && \
     cd /root && \
-    curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2021-02-11/arm-godot-linux-gnueabihf_sdk-buildroot.tar.bz2 && \
-    tar xf arm-godot-linux-gnueabihf_sdk-buildroot.tar.bz2 && \
-    rm -f arm-godot-linux-gnueabihf_sdk-buildroot.tar.bz2 && \
-    cd arm-godot-linux-gnueabihf_sdk-buildroot && \
-    ./relocate-sdk.sh && \
-    rm -f bin/{aclocal*,auto*,libtool*,m4} && \
-    cd /root && \
-    curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2021-02-11/i686-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
+    curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2023-12-11/i686-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     tar xf i686-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     rm -f i686-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     cd i686-godot-linux-gnu_sdk-buildroot && \
+    ./relocate-sdk.sh && \
+    rm -f bin/{aclocal*,auto*,libtool*,m4} && \
+    cd /root && \
+    curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2023-12-11/aarch64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
+    tar xf aarch64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
+    rm -f aarch64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
+    cd aarch64-godot-linux-gnu_sdk-buildroot && \
+    ./relocate-sdk.sh && \
+    rm -f bin/{aclocal*,auto*,libtool*,m4} && \
+    cd /root && \
+    curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2023-12-11/arm-godot-linux-gnueabihf_sdk-buildroot.tar.bz2 && \
+    tar xf arm-godot-linux-gnueabihf_sdk-buildroot.tar.bz2 && \
+    rm -f arm-godot-linux-gnueabihf_sdk-buildroot.tar.bz2 && \
+    cd arm-godot-linux-gnueabihf_sdk-buildroot && \
     ./relocate-sdk.sh && \
     rm -f bin/{aclocal*,auto*,libtool*,m4} && \
     cp -a /root/files/${mono_version} /root && \
@@ -37,7 +44,7 @@ RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mand
     export PATH=${GODOT_SDK_LINUX_X86_64}/bin:${BASE_PATH} && \
     python3 linux.py configure -j --target=x86_64 && \
     python3 linux.py make -j --target=x86_64 && \
-    export PATH=${GODOT_SDK_LINUX_X86}/bin:${BASE_PATH} && \
+    export PATH=${GODOT_SDK_LINUX_X86_32}/bin:${BASE_PATH} && \
     python3 linux.py configure -j --target=x86 && \
     python3 linux.py make -j --target=x86 && \
     export PATH=${GODOT_SDK_LINUX_X86_64}/bin:${BASE_PATH} && \

--- a/Dockerfile.mono
+++ b/Dockerfile.mono
@@ -3,8 +3,7 @@ FROM godot-fedora:${img_version}
 
 ARG mono_version
 
-RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
-    dnf -y install --setopt=install_weak_deps=False \
+RUN dnf -y install --setopt=install_weak_deps=False \
       autoconf automake cmake gcc gcc-c++ gettext libtool perl python-unversioned-command && \
     cp -a /root/files/${mono_version} /root && \
     cd /root/${mono_version} && \

--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -3,17 +3,18 @@ FROM godot-mono:${img_version}
 
 ARG mono_version
 
-RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
-    dnf -y install --setopt=install_weak_deps=False \
-      automake autoconf bzip2-devel cmake libicu-devel libtool libxml2-devel openssl-devel yasm && \
-    git clone --progress https://github.com/tpoechtrager/osxcross.git && \
+RUN dnf -y install --setopt=install_weak_deps=False \
+      automake autoconf bzip2-devel cmake gcc gcc-c++ libdispatch libicu-devel libtool \
+      libxml2-devel openssl-devel uuid-devel yasm && \
+    git clone --progress https://github.com/tpoechtrager/osxcross && \
     cd /root/osxcross && \
-    git checkout 17bb5e2d0a46533c1dd525cf4e9a80d88bd9f00e && \
-    ln -s /root/files/MacOSX12.3.sdk.tar.xz /root/osxcross/tarballs && \
-    patch -p1 < /root/files/patches/osxcross-pr367-fix-github-dl-page.diff && \
+    git checkout 5e1b71fcceb23952f3229995edca1b6231525b5b && \
+    ln -s /root/files/MacOSX14.0.sdk.tar.xz /root/osxcross/tarballs && \
     export UNATTENDED=1 && \
-    # Custom build to ensure we have Clang version matching Xcode SDK.
-    CLANG_VERSION=13.0.1 ENABLE_CLANG_INSTALL=1 INSTALLPREFIX=/usr ./build_clang.sh && \
+    # Custom build Apple Clang to ensure compatibility.
+    # Find the equivalent LLVM version for the SDK from:
+    # https://en.wikipedia.org/wiki/Xcode#Toolchain_versions
+    CLANG_VERSION=16.0.0 ENABLE_CLANG_INSTALL=1 INSTALLPREFIX=/usr ./build_apple_clang.sh && \
     ./build.sh && \
     ./build_compiler_rt.sh && \
     rm -rf /root/osxcross/build
@@ -25,7 +26,7 @@ RUN cp -a /root/files/${mono_version} /root && \
     cd /root/${mono_version} && \
     patch -p1 < /root/files/patches/mono-btls-cmake-wrapper.patch && \
     export MONO_SOURCE_ROOT=/root/${mono_version} && \
-    export OSXCROSS_SDK=21.4 && \
+    export OSXCROSS_SDK=23 && \
     cd /root/${mono_version}/godot-mono-builds && \
     python3 osx.py configure -j --target=x86_64 --target=arm64 && \
     python3 osx.py make -j --target=x86_64 --target=arm64 && \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -3,8 +3,7 @@ FROM godot-mono:${img_version}
 
 ARG mono_version
 
-RUN if [ -z "${mono_version}" ]; then echo -e "\n\nargument mono-version is mandatory!\n\n"; exit 1; fi && \
-    dnf -y install --setopt=install_weak_deps=False \
+RUN dnf -y install --setopt=install_weak_deps=False \
       mingw32-gcc mingw32-gcc-c++ mingw32-winpthreads-static mingw64-gcc mingw64-gcc-c++ mingw64-winpthreads-static && \
     cp -a /root/files/${mono_version} /root && \
     export MONO_SOURCE_ROOT=/root/${mono_version} && \

--- a/Dockerfile.xcode
+++ b/Dockerfile.xcode
@@ -3,9 +3,9 @@ FROM godot-fedora:${img_version}
 
 RUN dnf -y install --setopt=install_weak_deps=False \
       clang xar xar-devel xz-devel cpio && \
-    git clone --progress https://github.com/NiklasRosenstein/pbzx && \
+    git clone --progress https://github.com/nrosenstein-stuff/pbzx && \
     cd pbzx && \
-    git checkout 2a4d7c3300c826d918def713a24d25c237c8ed53 && \
+    git checkout bf536e167f2e514866f91d7baa0df1dff5a13711 && \
     clang -O3 -llzma -lxar -I /usr/local/include pbzx.c -o pbzx
 
 ENV XCODE_SDKV=
@@ -18,12 +18,6 @@ CMD mkdir -p /root/xcode && \
     /root/pbzx/pbzx -n Content | cpio -i && \
     export OSX_SDK=MacOSX${OSX_SDKV}.sdk && \
     cp -r Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk /tmp/${OSX_SDK} && \
-    mkdir -p /tmp/${OSX_SDK}/usr/include/c++ && \
-    cp -r Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1 /tmp/${OSX_SDK}/usr/include/c++/ && \
-    mkdir -p mkdir -p /tmp/${OSX_SDK}/usr/share/man && \
-    cp -rf Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/share/man/man1 \
-           Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/share/man/man3 \
-           Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/share/man/man5 /tmp/${OSX_SDK}/usr/share/man/ && \
     cd /tmp && \
     tar -cJf /root/files/${OSX_SDK}.tar.xz ${OSX_SDK} && \
     rm -rf ${OSX_SDK} && \
@@ -31,15 +25,11 @@ CMD mkdir -p /root/xcode && \
     export IOS_SDK=iPhoneOS${IOS_SDKV}.sdk && \
     export IOS_SIMULATOR_SDK=iPhoneSimulator${IOS_SDKV}.sdk && \
     cp -r Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk /tmp/${IOS_SDK} && \
-    mkdir -p /tmp/${IOS_SDK}/usr/include/c++ && \
-    cp -r Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1 /tmp/${IOS_SDK}/usr/include/c++/ && \
     cd /tmp && \
     tar -cJf /root/files/${IOS_SDK}.tar.xz ${IOS_SDK} && \
     rm -rf ${IOS_SDK} && \
     cd /root/xcode && \
-    cp -r Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk /tmp/${IOS_SDK} && \
-    mkdir -p /tmp/${IOS_SDK}/usr/include/c++ && \
-    cp -r Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1 /tmp/${IOS_SDK}/usr/include/c++/ && \
+    cp -r Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk /tmp/${IOS_SIMULATOR_SDK} && \
     cd /tmp && \
-    tar -cJf /root/files/${IOS_SIMULATOR_SDK}.tar.xz ${IOS_SDK} && \
-    rm -rf ${IOS_SDK}
+    tar -cJf /root/files/${IOS_SIMULATOR_SDK}.tar.xz ${IOS_SIMULATOR_SDK} && \
+    rm -rf ${IOS_SIMULATOR_SDK}

--- a/README.md
+++ b/README.md
@@ -44,20 +44,22 @@ the upstream `2020-02` branch (e.g. `mono-6.12.0.182`).
 
 Run the command using:
 
-    ./build.sh 3.x f36 mono-6.12.0.182
+    ./build.sh 3.x f39 mono-6.12.0.198
 
-The above will generate images using the tag '3.x-f36-mono-6.12.0.182'.
-You can then specify it in the `build.sh` of [godot-build-scripts]().
+The above will generate images using the tag '3.x-f39-mono-6.12.0.198'.
+You can then specify it in the `build.sh` of
+[godot-build-scripts](https://github.com/godotengine/godot-build-scripts).
+
 
 ### Selecting which images to build
 
 If you don't need to build all versions or you want to try with a single target OS first,
 you can comment out the corresponding lines from the script:
 
-    $podman_build_mono -t godot-linux:${img_version} -f Dockerfile.linux . 2>&1 | tee logs/linux.log
-    $podman_build_mono -t godot-windows:${img_version} -f Dockerfile.windows . 2>&1 | tee logs/windows.log
-    $podman_build_mono -t godot-javascript:${img_version} -f Dockerfile.javascript . 2>&1 | tee logs/javascript.log
-    $podman_build_mono -t godot-android:${img_version} -f Dockerfile.android . 2>&1 | tee logs/android.log
+    podman_build linux
+    podman_build windows
+    podman_build javascript
+    podman_build android
     ...
 
 **Note:** The MSVC image (used for UWP builds) does not work currently.
@@ -68,16 +70,17 @@ you can comment out the corresponding lines from the script:
 These are the expected container image sizes, so you can plan your disk usage in advance:
 
     REPOSITORY                                       TAG                        SIZE
-    localhost/godot-fedora                           3.x-f36-mono-6.12.0.182    546 MB
-    localhost/godot-export                           3.x-f36-mono-6.12.0.182    1.03 GB
-    localhost/godot-mono                             3.x-f36-mono-6.12.0.182    1.41 GB
-    localhost/godot-mono-glue                        3.x-f36-mono-6.12.0.182    1.75 GB
-    localhost/godot-linux                            3.x-f36-mono-6.12.0.182    3.8 GB
-    localhost/godot-windows                          3.x-f36-mono-6.12.0.182    3.31 GB
-    localhost/godot-javascript                       3.x-f36-mono-6.12.0.182    3.87 GB
-    localhost/godot-android                          3.x-f36-mono-6.12.0.182    6.06 GB
-    localhost/godot-osx                              3.x-f36-mono-6.12.0.182    5.71 GB
-    localhost/godot-ios                              3.x-f36-mono-6.12.0.182    6.53 GB
+    localhost/godot-fedora                           3.x-f39-mono-6.12.0.198    624 MB
+    localhost/godot-export                           3.x-f39-mono-6.12.0.198    1.14 GB
+    localhost/godot-mono                             3.x-f39-mono-6.12.0.198    1.52 GB
+    localhost/godot-mono-glue                        3.x-f39-mono-6.12.0.198    1.86 GB
+    localhost/godot-linux                            3.x-f39-mono-6.12.0.198    4.54 GB
+    localhost/godot-windows                          3.x-f39-mono-6.12.0.198    3.48 GB
+    localhost/godot-javascript                       3.x-f39-mono-6.12.0.198    3.97 GB
+    localhost/godot-android                          3.x-f39-mono-6.12.0.198    6.41 GB
+    localhost/godot-xcode                            3.x-f39-mono-6.12.0.198    1.07 GB
+    localhost/godot-osx                              3.x-f39-mono-6.12.0.198    6.05 GB
+    localhost/godot-ios                              3.x-f39-mono-6.12.0.198    7.48 GB
 
 In addition to this, generating containers will also require some host disk space
 (up to 30 GB) for the downloaded Mono sources and dependencies (Xcode, MSVC).
@@ -85,16 +88,16 @@ In addition to this, generating containers will also require some host disk spac
 
 ## Toolchains
 
-These are the toolchains currently in use for Godot 3.5 and later:
+These are the toolchains currently in use for Godot 3.6 and later:
 
-- Base image: Fedora 36
-- Mono version: 6.12.0.182
-- SCons: 4.3.0
-- Linux: GCC 10.2.0 built against glibc 2.19, binutils 2.35.1, from our own [Linux SDK](https://github.com/godotengine/buildroot)
-- Windows: MinGW 9.0.0, GCC 11.2.0, binutils 2.37
-- HTML5: Emscripten 3.1.14 (standard builds), Emscripten 1.39.9 (Mono builds)
-- Android: Android NDK 23.2.8568313, build-tools 32.0.0, platform android-32, CMake 3.18.1
-- macOS: Xcode 13.3.1 with LLVM Clang 13.0.1, MacOSX SDK 12.3
-- iOS: Xcode 13.3.1 with LLVM Clang 13.0.1, iPhoneOS SDK 15.4
+- Base image: Fedora 39
+- Mono version: 6.12.0.198
+- SCons: 4.5.2
+- Linux: GCC 13.2.0 built against glibc 2.28, binutils 2.40, from our own [Linux SDK](https://github.com/godotengine/buildroot)
+- Windows: MinGW 11.0.0, GCC 13.2.1, binutils 2.40
+- HTML5: Emscripten 3.1.39 (standard builds), Emscripten 1.39.9 (Mono builds)
+- Android: Android NDK 23.2.8568313, build-tools 33.0.2, platform android-33, CMake 3.22.1, JDK 11
+- macOS: Xcode 15.0 with Apple Clang (LLVM 16.0.0), MacOSX SDK 14.0
+- iOS: Xcode 15.0 with Apple Clang (LLVM 16.0.0), iPhoneOS SDK 17.0
 - UWP: Visual Studio 2017, current configuration sadly not easily reproducible
   (`Dockerfile.msvc` image is not compiled by default as it doesn't work)

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+podman=`command -v podman`
+
+if [ -z "$podman" ]; then
+  echo "podman needs to be in PATH for this script to work."
+  exit 1
+fi

--- a/upload.sh
+++ b/upload.sh
@@ -1,11 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
-
-podman=podman
-if ! which $podman; then
-  podman=docker
-fi
+source $(dirname "$0")/setup.sh
 
 img_version=$1
 registry=$2
@@ -19,14 +14,16 @@ if [ -z "${registry}" ]; then
   registry=registry.prehensile-tales.com
 fi
 
-$podman push godot-export:${img_version} ${registry}/godot/export
-$podman push godot-mono-glue:${img_version} ${registry}/godot/mono-glue
-$podman push godot-linux:${img_version} ${registry}/godot/linux
-$podman push godot-windows:${img_version} ${registry}/godot/windows
-$podman push godot-javascript:${img_version} ${registry}/godot/javascript
-$podman push godot-xcode-packer:${img_version} ${registry}/godot/xcode-packer
+"$podman" push godot-export:${img_version} ${registry}/godot/export
+"$podman" push godot-mono-glue:${img_version} ${registry}/godot/mono-glue
+"$podman" push godot-linux:${img_version} ${registry}/godot/linux
+"$podman" push godot-windows:${img_version} ${registry}/godot/windows
+"$podman" push godot-javascript:${img_version} ${registry}/godot/javascript
+"$podman" push godot-xcode-packer:${img_version} ${registry}/godot/xcode-packer
 
-$podman push godot-android:${img_version} ${registry}/godot-private/android
-$podman push godot-ios:${img_version} ${registry}/godot-private/ios
-$podman push godot-osx:${img_version} ${registry}/godot-private/macosx
-$podman push godot-msvc:${img_version} ${registry}/godot-private/uwp
+"$podman" push godot-android:${img_version} ${registry}/godot-private/android
+"$podman" push godot-ios:${img_version} ${registry}/godot-private/ios
+"$podman" push godot-osx:${img_version} ${registry}/godot-private/macosx
+
+# Not working currently.
+#"$podman" push godot-msvc:${img_version} ${registry}/godot-private/uwp


### PR DESCRIPTION
Syncs with the config of the current `main` branch (as used for 4.2+) as far as possible (backports the last couple of years of PRs, minus the removal of some platforms and of the Mono builds).

Notably backports #128 and #131, giving us these toolchains:

- Base image: Fedora 39
- Mono version: 6.12.0.198
- SCons: 4.5.2
- Linux: GCC 13.2.0 built against glibc 2.28, binutils 2.40, from our own [Linux SDK](https://github.com/godotengine/buildroot)
- Windows: MinGW 11.0.0, GCC 13.2.1, binutils 2.40
- HTML5: Emscripten 3.1.39 (standard builds), Emscripten 1.39.9 (Mono builds)
- Android: Android NDK 23.2.8568313, build-tools 33.0.2, platform android-33, CMake 3.22.1, JDK 11
- macOS: Xcode 15.0 with Apple Clang (LLVM 16.0.0), MacOSX SDK 14.0
- iOS: Xcode 15.0 with Apple Clang (LLVM 16.0.0), iPhoneOS SDK 17.0
- UWP: Unchanged, current Dockerfile still unsupported