### PR TITLE
[3.x] Update Linux SDK to 2024-01-17 release, fixes arm32 lacking NEON

### DIFF
--- a/Dockerfile.linux
+++ b/Dockerfile.linux
@@ -11,28 +11,28 @@ ENV BASE_PATH=${PATH}
 
 RUN dnf -y install --setopt=install_weak_deps=False \
       libxcrypt-compat yasm && \
-    curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2023-12-11/x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
+    curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2024-01-17/x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     tar xf x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     rm -f x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     cd x86_64-godot-linux-gnu_sdk-buildroot && \
     ./relocate-sdk.sh && \
     rm -f bin/{aclocal*,auto*,libtool*,m4} && \
     cd /root && \
-    curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2023-12-11/i686-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
+    curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2024-01-17/i686-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     tar xf i686-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     rm -f i686-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     cd i686-godot-linux-gnu_sdk-buildroot && \
     ./relocate-sdk.sh && \
     rm -f bin/{aclocal*,auto*,libtool*,m4} && \
     cd /root && \
-    curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2023-12-11/aarch64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
+    curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2024-01-17/aarch64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     tar xf aarch64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     rm -f aarch64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     cd aarch64-godot-linux-gnu_sdk-buildroot && \
     ./relocate-sdk.sh && \
     rm -f bin/{aclocal*,auto*,libtool*,m4} && \
     cd /root && \
-    curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2023-12-11/arm-godot-linux-gnueabihf_sdk-buildroot.tar.bz2 && \
+    curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2024-01-17/arm-godot-linux-gnueabihf_sdk-buildroot.tar.bz2 && \
     tar xf arm-godot-linux-gnueabihf_sdk-buildroot.tar.bz2 && \
     rm -f arm-godot-linux-gnueabihf_sdk-buildroot.tar.bz2 && \
     cd arm-godot-linux-gnueabihf_sdk-buildroot && \


### PR DESCRIPTION
Same as https://github.com/godotengine/build-containers/pull/136.