### PR TITLE
Update various toolchains for 4.3

### DIFF
--- a/Dockerfile.ios
+++ b/Dockerfile.ios
@@ -1,15 +1,13 @@
 ARG img_version
 FROM godot-osx:${img_version}
 
-ENV IOS_SDK=17.0
+ENV IOS_SDK=17.2
 
 RUN dnf -y install --setopt=install_weak_deps=False \
       automake autoconf gcc gcc-c++ gcc-objc gcc-objc++ cmake libicu-devel libtool libxml2-devel openssl-devel perl python yasm && \
     git clone --progress https://github.com/tpoechtrager/cctools-port && \
     cd /root/cctools-port && \
-    git checkout 437ced391dbf14dce86f977ca050a750d5682f39 && \
-    curl -LO https://github.com/tpoechtrager/cctools-port/pull/136.patch && \
-    git apply 136.patch && \
+    git checkout a98286d858210b209395624477533c0bde05556a && \
     # arm64 device
     usage_examples/ios_toolchain/build.sh /root/files/iPhoneOS${IOS_SDK}.sdk.tar.xz arm64 && \
     mkdir -p /root/ioscross/arm64 && \

--- a/Dockerfile.linux
+++ b/Dockerfile.linux
@@ -7,7 +7,8 @@ ENV GODOT_SDK_LINUX_ARM64=/root/aarch64-godot-linux-gnu_sdk-buildroot
 ENV GODOT_SDK_LINUX_ARM32=/root/arm-godot-linux-gnueabihf_sdk-buildroot
 ENV BASE_PATH=${PATH}
 
-RUN curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2024-01-17/x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
+RUN dnf install -y wayland-devel && \
+    curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2024-01-17/x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     tar xf x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     rm -f x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     cd x86_64-godot-linux-gnu_sdk-buildroot && \

--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -1,14 +1,19 @@
 ARG img_version
 FROM godot-fedora:${img_version}
 
+ENV OSX_SDK=14.2
+
 RUN dnf -y install --setopt=install_weak_deps=False \
       automake autoconf bzip2-devel cmake gcc gcc-c++ libdispatch libicu-devel libtool \
       libxml2-devel openssl-devel uuid-devel yasm && \
     git clone --progress https://github.com/tpoechtrager/osxcross && \
     cd /root/osxcross && \
-    git checkout 5e1b71fcceb23952f3229995edca1b6231525b5b && \
-    ln -s /root/files/MacOSX14.0.sdk.tar.xz /root/osxcross/tarballs && \
+    git checkout ff8d100f3f026b4ffbe4ce96d8aac4ce06f1278b && \
+    curl -LO https://github.com/tpoechtrager/osxcross/pull/415.patch && \
+    git apply 415.patch && \
+    ln -s /root/files/MacOSX${OSX_SDK}.sdk.tar.xz /root/osxcross/tarballs && \
     export UNATTENDED=1 && \
+    export SDK_VERSION=${OSX_SDK} && \
     # Custom build Apple Clang to ensure compatibility.
     # Find the equivalent LLVM version for the SDK from:
     # https://en.wikipedia.org/wiki/Xcode#Toolchain_versions

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,7 +1,7 @@
 ARG img_version
 FROM godot-fedora:${img_version}
 
-ENV EMSCRIPTEN_VERSION=3.1.39
+ENV EMSCRIPTEN_VERSION=3.1.53
 
 RUN git clone --branch ${EMSCRIPTEN_VERSION} --progress https://github.com/emscripten-core/emsdk && \
     emsdk/emsdk install ${EMSCRIPTEN_VERSION} && \

--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ you can comment out the corresponding lines from the script:
 These are the expected container image sizes, so you can plan your disk usage in advance:
 
     REPOSITORY                         TAG                SIZE
-    localhost/godot-fedora             4.x-f39            1.08 GB
-    localhost/godot-linux              4.x-f39            2.86 GB
-    localhost/godot-windows            4.x-f39            1.89 GB
-    localhost/godot-web                4.x-f39            2.24 GB
-    localhost/godot-android            4.x-f39            3.67 GB
-    localhost/godot-osx                4.x-f39            4.70 GB
-    localhost/godot-ios                4.x-f39            5.30 GB
+    localhost/godot-fedora             4.x-f39            1.20 GB
+    localhost/godot-linux              4.x-f39            3.00 GB
+    localhost/godot-windows            4.x-f39            2.02 GB
+    localhost/godot-web                4.x-f39            2.42 GB
+    localhost/godot-android            4.x-f39            4.48 GB
+    localhost/godot-osx                4.x-f39            4.94 GB
+    localhost/godot-ios                4.x-f39            5.68 GB
 
 In addition to this, generating containers will also require some host disk space
 (up to 10 GB) for the dependencies (Xcode).
@@ -82,10 +82,10 @@ In addition to this, generating containers will also require some host disk spac
 These are the toolchains currently in use for Godot 4.2 and later:
 
 - Base image: Fedora 39
-- SCons: 4.5.2
+- SCons: 4.6.0
 - Linux: GCC 13.2.0 built against glibc 2.28, binutils 2.40, from our own [Linux SDK](https://github.com/godotengine/buildroot)
 - Windows: MinGW 11.0.0, GCC 13.2.1, binutils 2.40
-- Web: Emscripten 3.1.39
-- Android: Android NDK 23.2.8568313, build-tools 33.0.2, platform android-33, CMake 3.22.1, JDK 17
-- macOS: Xcode 15.0 with Apple Clang (LLVM 16.0.0), MacOSX SDK 14.0
-- iOS: Xcode 15.0 with Apple Clang (LLVM 16.0.0), iPhoneOS SDK 17.0
+- Web: Emscripten 3.1.53
+- Android: Android NDK 23.2.8568313, build-tools 34.0.0, platform android-34, CMake 3.22.1, JDK 17
+- macOS: Xcode 15.2 with Apple Clang (LLVM 16.0.0), MacOSX SDK 14.2
+- iOS: Xcode 15.2 with Apple Clang (LLVM 16.0.0), iPhoneOS SDK 17.2

--- a/build.sh
+++ b/build.sh
@@ -58,9 +58,9 @@ podman_build windows
 podman_build web
 podman_build android
 
-XCODE_SDK=15
-OSX_SDK=14.0
-IOS_SDK=17.0
+XCODE_SDK=15.2
+OSX_SDK=14.2
+IOS_SDK=17.2
 if [ ! -e "${files_root}"/MacOSX${OSX_SDK}.sdk.tar.xz ] || [ ! -e "${files_root}"/iPhoneOS${IOS_SDK}.sdk.tar.xz ] || [ ! -e "${files_root}"/iPhoneSimulator${IOS_SDK}.sdk.tar.xz ]; then
   if [ ! -e "${files_root}"/Xcode_${XCODE_SDK}.xip ]; then
     echo "files/Xcode_${XCODE_SDK}.xip is required. It can be downloaded from https://developer.apple.com/download/more/ with a valid apple ID."


### PR DESCRIPTION
- .NET 8.0
- SCons 4.6.0
- Xcode 15.2 (macOS 14.2, iOS 17.2)
- Android API 34
- Emscripten 3.1.53
- Add wayland-devel dependency for Linux

---

Note: I used an intermediate version of this patch for the 4.3-dev3 release, without the OSX and iOS changes.