### PR TITLE
Update various toolchains for 4.3

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM fedora:39
+FROM fedora:40
 
 WORKDIR /root
 
@@ -8,6 +8,6 @@ ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 RUN dnf -y install --setopt=install_weak_deps=False \
       bash bzip2 curl file findutils gettext git make nano patch pkgconfig python3-pip unzip which xz \
       dotnet-sdk-8.0 && \
-    pip install scons==4.6.0
+    pip install scons==4.7.0
 
 CMD /bin/bash

--- a/Dockerfile.ios
+++ b/Dockerfile.ios
@@ -1,7 +1,7 @@
 ARG img_version
 FROM godot-osx:${img_version}
 
-ENV IOS_SDK=17.2
+ENV IOS_SDK=17.5
 
 RUN dnf -y install --setopt=install_weak_deps=False \
       automake autoconf gcc gcc-c++ gcc-objc gcc-objc++ cmake libicu-devel libtool libxml2-devel openssl-devel perl python yasm && \

--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -1,7 +1,7 @@
 ARG img_version
 FROM godot-fedora:${img_version}
 
-ENV OSX_SDK=14.2
+ENV OSX_SDK=14.5
 
 RUN dnf -y install --setopt=install_weak_deps=False \
       automake autoconf bzip2-devel cmake gcc gcc-c++ libdispatch libicu-devel libtool \

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,7 +1,7 @@
 ARG img_version
 FROM godot-fedora:${img_version}
 
-ENV EMSCRIPTEN_VERSION=3.1.53
+ENV EMSCRIPTEN_VERSION=3.1.61
 
 RUN git clone --branch ${EMSCRIPTEN_VERSION} --progress https://github.com/emscripten-core/emsdk && \
     emsdk/emsdk install ${EMSCRIPTEN_VERSION} && \

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ The `build.sh` script included is used to build the containers themselves.
 
 The two arguments can take any value and are meant to convey what Godot branch
 you are building for (e.g. `4.x`) and what Linux distribution the `Dockerfile.base`
-is based on (e.g. `f39` for Fedora 39).
+is based on (e.g. `f40` for Fedora 40).
 
 Run the command using:
 
-    ./build.sh 4.x f39
+    ./build.sh 4.x f40
 
-The above will generate images using the tag '4.x-f39'.
+The above will generate images using the tag '4.x-f40'.
 You can then specify it in the `build.sh` of
 [godot-build-scripts](https://github.com/godotengine/godot-build-scripts).
 
@@ -65,13 +65,13 @@ you can comment out the corresponding lines from the script:
 These are the expected container image sizes, so you can plan your disk usage in advance:
 
     REPOSITORY                         TAG                SIZE
-    localhost/godot-fedora             4.x-f39            1.20 GB
-    localhost/godot-linux              4.x-f39            3.00 GB
-    localhost/godot-windows            4.x-f39            2.02 GB
-    localhost/godot-web                4.x-f39            2.42 GB
-    localhost/godot-android            4.x-f39            4.48 GB
-    localhost/godot-osx                4.x-f39            4.94 GB
-    localhost/godot-ios                4.x-f39            5.68 GB
+    localhost/godot-fedora             4.x-f40            1.20 GB
+    localhost/godot-linux              4.x-f40            3.00 GB
+    localhost/godot-windows            4.x-f40            2.02 GB
+    localhost/godot-web                4.x-f40            2.42 GB
+    localhost/godot-android            4.x-f40            4.48 GB
+    localhost/godot-osx                4.x-f40            4.94 GB
+    localhost/godot-ios                4.x-f40            5.68 GB
 
 In addition to this, generating containers will also require some host disk space
 (up to 10 GB) for the dependencies (Xcode).
@@ -79,13 +79,13 @@ In addition to this, generating containers will also require some host disk spac
 
 ## Toolchains
 
-These are the toolchains currently in use for Godot 4.2 and later:
+These are the toolchains currently in use for Godot 4.3 and later:
 
-- Base image: Fedora 39
-- SCons: 4.6.0
+- Base image: Fedora 40
+- SCons: 4.7.0
 - Linux: GCC 13.2.0 built against glibc 2.28, binutils 2.40, from our own [Linux SDK](https://github.com/godotengine/buildroot)
-- Windows: MinGW 11.0.0, GCC 13.2.1, binutils 2.40
-- Web: Emscripten 3.1.53
+- Windows: MinGW 11.0.1, GCC 14.1.1, binutils 2.41
+- Web: Emscripten 3.1.61
 - Android: Android NDK 23.2.8568313, build-tools 34.0.0, platform android-34, CMake 3.22.1, JDK 17
-- macOS: Xcode 15.2 with Apple Clang (LLVM 16.0.0), MacOSX SDK 14.2
-- iOS: Xcode 15.2 with Apple Clang (LLVM 16.0.0), iPhoneOS SDK 17.2
+- macOS: Xcode 15.5 with Apple Clang (LLVM 16.0.0), MacOSX SDK 14.5
+- iOS: Xcode 15.5 with Apple Clang (LLVM 16.0.0), iPhoneOS SDK 17.5

--- a/build.sh
+++ b/build.sh
@@ -58,9 +58,9 @@ podman_build windows
 podman_build web
 podman_build android
 
-XCODE_SDK=15.2
-OSX_SDK=14.2
-IOS_SDK=17.2
+XCODE_SDK=15.4
+OSX_SDK=14.5
+IOS_SDK=17.5
 if [ ! -e "${files_root}"/MacOSX${OSX_SDK}.sdk.tar.xz ] || [ ! -e "${files_root}"/iPhoneOS${IOS_SDK}.sdk.tar.xz ] || [ ! -e "${files_root}"/iPhoneSimulator${IOS_SDK}.sdk.tar.xz ]; then
   if [ ! -e "${files_root}"/Xcode_${XCODE_SDK}.xip ]; then
     echo "files/Xcode_${XCODE_SDK}.xip is required. It can be downloaded from https://developer.apple.com/download/more/ with a valid apple ID."


### PR DESCRIPTION
- Fedora 40
- SCons 4.7.0
- MinGW 11.0.1 with GCC 14.1.1 and binutils 2.41
- Xcode 15.5 (macOS 14.5, iOS 17.5)
- Emscripten 3.1.61