### PR TITLE
Web: Patch Emscripten 3.1.61 to include PR 19496, fixing threads+dlink build

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -5,6 +5,9 @@ ENV EMSCRIPTEN_VERSION=3.1.61
 
 RUN git clone --branch ${EMSCRIPTEN_VERSION} --progress https://github.com/emscripten-core/emsdk && \
     emsdk/emsdk install ${EMSCRIPTEN_VERSION} && \
-    emsdk/emsdk activate ${EMSCRIPTEN_VERSION}
+    emsdk/emsdk activate ${EMSCRIPTEN_VERSION} && \
+    cd emsdk/upstream/emscripten && \
+    curl -LO https://github.com/emscripten-core/emscripten/pull/19496.patch && \
+    patch -p1 < 19496.patch
 
 CMD /bin/bash


### PR DESCRIPTION
Backporting https://github.com/emscripten-core/emscripten/pull/19496 while we wait for 3.1.62.