### PR TITLE
Add pre-built MinGW/LLVM toolchain to the Windows build container to support ARM64 Windows builds.

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -2,7 +2,7 @@ ARG img_version
 FROM godot-fedora:${img_version}
 
 RUN dnf -y install --setopt=install_weak_deps=False \
-    mingw32-gcc mingw32-gcc-c++ mingw32-winpthreads-static mingw64-gcc mingw64-gcc-c++ mingw64-winpthreads-static && \
+      mingw32-gcc mingw32-gcc-c++ mingw32-winpthreads-static mingw64-gcc mingw64-gcc-c++ mingw64-winpthreads-static && \
     curl -LO https://github.com/mstorsjo/llvm-mingw/releases/download/20240619/llvm-mingw-20240619-ucrt-ubuntu-20.04-x86_64.tar.xz && \
     tar xf llvm-mingw-20240619-ucrt-ubuntu-20.04-x86_64.tar.xz && \
     rm -f llvm-mingw-20240619-ucrt-ubuntu-20.04-x86_64.tar.xz && \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -2,6 +2,10 @@ ARG img_version
 FROM godot-fedora:${img_version}
 
 RUN dnf -y install --setopt=install_weak_deps=False \
-      mingw32-gcc mingw32-gcc-c++ mingw32-winpthreads-static mingw64-gcc mingw64-gcc-c++ mingw64-winpthreads-static
+    mingw32-gcc mingw32-gcc-c++ mingw32-winpthreads-static mingw64-gcc mingw64-gcc-c++ mingw64-winpthreads-static && \
+    curl -LO https://github.com/mstorsjo/llvm-mingw/releases/download/20240619/llvm-mingw-20240619-ucrt-ubuntu-20.04-x86_64.tar.xz && \
+    tar xf llvm-mingw-20240619-ucrt-ubuntu-20.04-x86_64.tar.xz && \
+    rm -f llvm-mingw-20240619-ucrt-ubuntu-20.04-x86_64.tar.xz && \
+    mv -f llvm-mingw-20240619-ucrt-ubuntu-20.04-x86_64 /root/llvm-mingw
 
 CMD /bin/bash


### PR DESCRIPTION
Adds commands to download and extract [MinGW/LLVM](https://github.com/mstorsjo/llvm-mingw) toolchain. Toolchain is installed in `/root/llvm-mingw`.