### PR TITLE
Update various toolchains for 4.5

### DIFF
--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -2,17 +2,17 @@ ARG img_version
 FROM godot-fedora:${img_version}
 
 ENV ANDROID_SDK_ROOT=/root/sdk
-ENV ANDROID_NDK_VERSION=23.2.8568313
+ENV ANDROID_NDK_VERSION=28.1.13356709
 ENV ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk/${ANDROID_NDK_VERSION}
 
 RUN dnf -y install --setopt=install_weak_deps=False \
-      java-17-openjdk-devel ncurses-compat-libs && \
+      java-21-openjdk-devel ncurses-compat-libs && \
     mkdir -p sdk && cd sdk && \
-    export CMDLINETOOLS=commandlinetools-linux-11076708_latest.zip && \
+    export CMDLINETOOLS=commandlinetools-linux-13114758_latest.zip && \
     curl -LO https://dl.google.com/android/repository/${CMDLINETOOLS} && \
     unzip ${CMDLINETOOLS} && \
     rm ${CMDLINETOOLS} && \
     yes | cmdline-tools/bin/sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" --licenses && \
-    cmdline-tools/bin/sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" "ndk;${ANDROID_NDK_VERSION}" 'cmdline-tools;latest' 'build-tools;34.0.0' 'platforms;android-34' 'cmake;3.22.1'
+    cmdline-tools/bin/sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" "ndk;${ANDROID_NDK_VERSION}" 'cmdline-tools;latest' 'build-tools;35.0.0' 'platforms;android-35' 'cmake;3.31.6'
 
 CMD /bin/bash

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM fedora:41
+FROM fedora:42
 
 WORKDIR /root
 
@@ -8,6 +8,6 @@ ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 RUN dnf -y install --setopt=install_weak_deps=False \
       bash binutils bzip2 curl file findutils gettext git make nano patch pkgconfig python3-pip unzip which xz \
       dotnet-sdk-8.0 && \
-    pip install scons==4.8.1
+    pip install scons==4.9.1
 
 CMD /bin/bash

--- a/Dockerfile.ios
+++ b/Dockerfile.ios
@@ -1,13 +1,13 @@
 ARG img_version
 FROM godot-osx:${img_version}
 
-ENV IOS_SDK=18.2
+ENV IOS_SDK=18.4
 
 RUN dnf -y install --setopt=install_weak_deps=False \
       automake autoconf gcc gcc-c++ gcc-objc gcc-objc++ cmake libicu-devel libtool libxml2-devel openssl-devel perl python yasm && \
     git clone --progress https://github.com/tpoechtrager/cctools-port && \
     cd /root/cctools-port && \
-    git checkout 81f205e8ca6bbf2fdbcb6948132454fd1f97839e && \
+    git checkout 7224fd5c9390ea15cff6ee69ff92ea677b40014b && \
     # arm64 device
     usage_examples/ios_toolchain/build.sh /root/files/iPhoneOS${IOS_SDK}.sdk.tar.xz arm64 && \
     mkdir -p /root/ioscross/arm64 && \

--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -1,23 +1,21 @@
 ARG img_version
 FROM godot-fedora:${img_version}
 
-ENV OSX_SDK=15.2
+ENV OSX_SDK=15.4
 
 RUN dnf -y install --setopt=install_weak_deps=False \
-      automake autoconf bzip2-devel cmake gcc gcc-c++ libdispatch libicu-devel libtool \
+      automake autoconf bzip2-devel cmake gawk gcc gcc-c++ libdispatch libicu-devel libtool \
       libxml2-devel openssl-devel uuid-devel yasm && \
     git clone --progress https://github.com/tpoechtrager/osxcross && \
     cd /root/osxcross && \
-    git checkout 29fe6dd35522073c9df5800f8cd1feb4b9a993a8 && \
-    curl -LO https://github.com/tpoechtrager/osxcross/pull/441.patch && \
-    git apply 441.patch && \
+    git checkout 310196974007fc916f9be1877731b716a4854f72 && \
     ln -s /root/files/MacOSX${OSX_SDK}.sdk.tar.xz /root/osxcross/tarballs && \
     export UNATTENDED=1 && \
     export SDK_VERSION=${OSX_SDK} && \
     # Custom build Apple Clang to ensure compatibility.
     # Find the equivalent LLVM version for the SDK from:
     # https://en.wikipedia.org/wiki/Xcode#Toolchain_versions
-    CLANG_VERSION=17.0.6 ENABLE_CLANG_INSTALL=1 INSTALLPREFIX=/usr ./build_apple_clang.sh && \
+    CLANG_VERSION=19.1.4 ENABLE_CLANG_INSTALL=1 INSTALLPREFIX=/usr ./build_apple_clang.sh && \
     ./build.sh && \
     ./build_compiler_rt.sh && \
     rm -rf /root/osxcross/build

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,7 +1,7 @@
 ARG img_version
 FROM godot-fedora:${img_version}
 
-ENV EMSCRIPTEN_VERSION=3.1.64
+ENV EMSCRIPTEN_VERSION=4.0.8
 
 RUN git clone --branch ${EMSCRIPTEN_VERSION} --progress https://github.com/emscripten-core/emsdk && \
     emsdk/emsdk install ${EMSCRIPTEN_VERSION} && \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -3,9 +3,11 @@ FROM godot-fedora:${img_version}
 
 RUN dnf -y install --setopt=install_weak_deps=False \
       mingw32-gcc mingw32-gcc-c++ mingw32-winpthreads-static mingw64-gcc mingw64-gcc-c++ mingw64-winpthreads-static && \
-    curl -LO https://github.com/mstorsjo/llvm-mingw/releases/download/20241203/llvm-mingw-20241203-ucrt-ubuntu-20.04-x86_64.tar.xz && \
-    tar xf llvm-mingw-20241203-ucrt-ubuntu-20.04-x86_64.tar.xz && \
-    rm -f llvm-mingw-20241203-ucrt-ubuntu-20.04-x86_64.tar.xz && \
-    mv -f llvm-mingw-20241203-ucrt-ubuntu-20.04-x86_64 /root/llvm-mingw
+    export LLVM_MINGW_VERSION=20250514 && \
+    export LLVM_MINGW_NAME=llvm-mingw-${LLVM_MINGW_VERSION}-ucrt-ubuntu-22.04-x86_64 && \
+    curl -LO https://github.com/mstorsjo/llvm-mingw/releases/download/${LLVM_MINGW_VERSION}/${LLVM_MINGW_NAME}.tar.xz && \
+    tar xf ${LLVM_MINGW_NAME}.tar.xz && \
+    rm -f ${LLVM_MINGW_NAME}.tar.xz && \
+    mv -f ${LLVM_MINGW_NAME} /root/llvm-mingw
 
 CMD /bin/bash

--- a/README.md
+++ b/README.md
@@ -22,13 +22,15 @@ documented here.
 
 ## Requirements
 
-These containers have been tested under Fedora 36 (other distros/releases may work too).
+These containers have been tested under currently supported Fedora releases
+(other distros may work too).
 
-The tool used to build and manage the containers is `podman` (install it with `dnf -y podman`).
+The tool used to build and manage the containers is `podman` (install it with
+`dnf -y podman`).
 
-We currently use `podman` as root to build and use these containers. Documenting a workflow to
-configure the host OS to be able to do all this without root would be welcome (but back when we
-tried we ran into performance issues).
+We currently use `podman` as root to build and use these containers. Documenting
+a workflow to configure the host OS to be able to do all this without root would
+be welcome (but back when we tried we ran into performance issues).
 
 
 ## Usage
@@ -36,14 +38,14 @@ tried we ran into performance issues).
 The `build.sh` script included is used to build the containers themselves.
 
 The two arguments can take any value and are meant to convey what Godot branch
-you are building for (e.g. `4.3`) and what Linux distribution the `Dockerfile.base`
-is based on (e.g. `f40` for Fedora 40).
+you are building for (e.g. `4.5`) and what Linux distribution the `Dockerfile.base`
+is based on (e.g. `f42` for Fedora 42).
 
 Run the command using:
 
-    ./build.sh 4.3 f40
+    ./build.sh 4.5 f42
 
-The above will generate images using the tag '4.3-f40'.
+The above will generate images using the tag '4.5-f42'.
 You can then specify it in the `build.sh` of
 [godot-build-scripts](https://github.com/godotengine/godot-build-scripts).
 
@@ -65,13 +67,13 @@ you can comment out the corresponding lines from the script:
 These are the expected container image sizes, so you can plan your disk usage in advance:
 
     REPOSITORY                         TAG                SIZE
-    localhost/godot-fedora             4.3-f40            1.01 GB
-    localhost/godot-linux              4.3-f40            2.80 GB
-    localhost/godot-windows            4.3-f40            2.46 GB
-    localhost/godot-web                4.3-f40            2.41 GB
-    localhost/godot-android            4.3-f40            4.29 GB
-    localhost/godot-osx                4.3-f40            4.78 GB
-    localhost/godot-ios                4.3-f40            5.49 GB
+    localhost/godot-fedora             4.5-f42            949 MB
+    localhost/godot-linux              4.5-f42            2.74 GB
+    localhost/godot-windows            4.5-f42            2.54 GB
+    localhost/godot-web                4.5-f42            2.35 GB
+    localhost/godot-android            4.5-f42            4.19 GB
+    localhost/godot-osx                4.5-f42            5.30 GB
+    localhost/godot-ios                4.5-f42            6.11 GB
 
 In addition to this, generating containers will also require some host disk space
 (up to 10 GB) for the dependencies (Xcode).
@@ -81,13 +83,14 @@ In addition to this, generating containers will also require some host disk spac
 
 These are the toolchains currently in use for Godot 4.3 and later:
 
-- Base image: Fedora 41
-- SCons: 4.8.1
+- Base image: Fedora 42
+- SCons: 4.9.1
 - Linux: GCC 13.2.0 built against glibc 2.28, binutils 2.40, from our own [Linux SDK](https://github.com/godotengine/buildroot)
 - Windows:
-  * x86_64/x86_32: MinGW 12.0.0, GCC 14.2.1, binutils 2.42
-  * arm64: llvm-mingw 20241203, LLVM 19.1.5
-- Web: Emscripten 3.1.64
-- Android: Android NDK 23.2.8568313, build-tools 34.0.0, platform android-34, CMake 3.22.1, JDK 17
-- macOS: Xcode 16.2 with Apple Clang (LLVM 17.0.6), MacOSX SDK 15.2
-- iOS: Xcode 16.2 with Apple Clang (LLVM 17.0.6), iPhoneOS SDK 18.2
+  * x86_64/x86_32: MinGW 12.0.0, GCC 14.2.1, binutils 2.43.1
+  * arm64: llvm-mingw 20250514, LLVM 20.1.5
+- Web: Emscripten 4.0.8
+- Android: Android NDK 28.1.13356709, build-tools 35.0.0, platform android-35, CMake 3.31.6, JDK 21
+- Apple: Xcode 16.3 with Apple Clang (LLVM 19.1.4), cctools 1024.3, ld64 955.13
+  * macOS: MacOSX SDK 15.4
+  * iOS: iPhoneOS SDK 18.4

--- a/build.sh
+++ b/build.sh
@@ -58,9 +58,9 @@ podman_build windows
 podman_build web
 podman_build android
 
-XCODE_SDK=16.2
-OSX_SDK=15.2
-IOS_SDK=18.2
+XCODE_SDK=16.3
+OSX_SDK=15.4
+IOS_SDK=18.4
 if [ ! -e "${files_root}"/MacOSX${OSX_SDK}.sdk.tar.xz ] || [ ! -e "${files_root}"/iPhoneOS${IOS_SDK}.sdk.tar.xz ] || [ ! -e "${files_root}"/iPhoneSimulator${IOS_SDK}.sdk.tar.xz ]; then
   if [ ! -r "${files_root}"/Xcode_${XCODE_SDK}.xip ]; then
     echo


### PR DESCRIPTION
- Fedora 42
- SCons 4.9.1
- Windows: MinGW 12.0.0 with GCC 14.2.1 and binutils 2.43.1
- Android: NDK r28b, API 25, Java 21
  * CC @m4gr3d - Depends on https://github.com/godotengine/godot/pull/106152, https://github.com/godotengine/godot/pull/106358, https://github.com/godotengine/godot/pull/106466
- Web: Emscripten 4.0.8
  * CC @adamscott - I'm not sure we support it yet, and so far we've still built with 3.1.64, but it's probably time to start considering which version we want to use for 4.5.
- Apple: Xcode 16.3 (macOS 15.4, iOS 18.4)
  * Will open a follow-up that starts working on visionOS support.
- Linux: No change, still GCC 13.2.0
  * CC @hp - Our buildroot fork is based on `2023.08.x`, and the latest branch upstream is https://github.com/buildroot/buildroot/tree/2025.02.x. Might be a good time now to update and go from GCC 13.2.0 to 14.2.0.