### PR TITLE
Update osx env variable to 16.2

### DIFF
--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -1,7 +1,7 @@
 ARG img_version
 FROM godot-fedora:${img_version}
 
-ENV OSX_SDK=15.2
+ENV OSX_SDK=16.2
 
 RUN dnf -y install --setopt=install_weak_deps=False \
       automake autoconf bzip2-devel cmake gcc gcc-c++ libdispatch libicu-devel libtool \


### PR DESCRIPTION
Description:
THis PR updates the env variable to the latest xcode sdk version 16.2.

Reason:
If we build this container, with the latest package, it could result in an error since the file name is dynamically created with the ENV variable

```
extracting MacOSX15.2.sdk.tar.xz ...
xz: /root/osxcross/tarballs/MacOSX15.2.sdk.tar.xz: No such file or directory
tar: This does not look like a tar archive
tar: Exiting with failure status due to previous errors
```

