### PR TITLE
Apple: Update to Apple 26.0 SDKs; patch llvm-project/release/21; add swift toolchain

### DIFF
--- a/Dockerfile.appleembedded
+++ b/Dockerfile.appleembedded
@@ -4,20 +4,6 @@ FROM godot-osx:${img_version}
 RUN dnf -y install --setopt=install_weak_deps=False \
       automake autoconf gcc gcc-c++ gcc-objc gcc-objc++ cmake libicu-devel libtool libxml2-devel openssl-devel perl python yasm
 
-ENV IOS_SDK=18.5
-ENV TVOS_SDK=18.5
-ENV XROS_SDK=2.5
-
-# Extract the SDKs for iOS, tvOS and XROS, including the simulator SDKs
-# into separate layers, so this work is not repeated each time the image is built.
-RUN mkdir -p /root/SDKs
-RUN cd /root/SDKs && tar xf /root/files/iPhoneOS${IOS_SDK}.sdk.tar.xz
-RUN cd /root/SDKs && tar xf /root/files/iPhoneSimulator${IOS_SDK}.sdk.tar.xz
-RUN cd /root/SDKs && tar xf /root/files/AppleTVOS${TVOS_SDK}.sdk.tar.xz
-RUN cd /root/SDKs && tar xf /root/files/AppleTVSimulator${TVOS_SDK}.sdk.tar.xz
-RUN cd /root/SDKs && tar xf /root/files/XROS${XROS_SDK}.sdk.tar.xz
-RUN cd /root/SDKs && tar xf /root/files/XRSimulator${XROS_SDK}.sdk.tar.xz
-
 RUN git clone --depth 1 --no-checkout https://github.com/tpoechtrager/cctools-port.git && \
     cd /root/cctools-port && \
     git fetch --depth 1 origin 7224fd5c9390ea15cff6ee69ff92ea677b40014b && \

--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -1,14 +1,20 @@
 ARG img_version
 FROM godot-fedora:${img_version}
 
-ENV OSX_SDK=15.5
+# Additional packages for Swift
+#
+# sudo dnf install gnupg2
+
+ENV XCODE_SDKV=26.0.1
+ENV APPLE_SDKV=26.0
+ENV OSX_SDK=26.0
 
 RUN dnf -y install --setopt=install_weak_deps=False \
       automake autoconf bzip2-devel cmake gawk gcc gcc-c++ libdispatch libicu-devel libtool \
-      libxml2-devel openssl-devel uuid-devel yasm && \
+      libxml2-devel openssl-devel uuid-devel yasm gpg && \
     git clone --progress https://github.com/tpoechtrager/osxcross && \
     cd /root/osxcross && \
-    git checkout 310196974007fc916f9be1877731b716a4854f72 && \
+    git checkout f873f534c6cdb0776e457af8c7513da1e02abe59 && \
     # Patch to fix visionOS support.
     # See: https://github.com/llvm/llvm-project/issues/142502
     patch -p1 < /root/files/patches/osxcross-fix-visionos.patch && \
@@ -25,5 +31,18 @@ RUN dnf -y install --setopt=install_weak_deps=False \
 
 ENV OSXCROSS_ROOT=/root/osxcross
 ENV PATH="/root/osxcross/target/bin:${PATH}"
+
+# Install Swift 6.2 toolchain
+
+RUN mkdir -p /root/Xcode.app/Contents/Developer
+RUN cd /root/Xcode.app/Contents/Developer && tar xf /root/files/Xcode-Developer${XCODE_SDKV}.tar.xz --strip-components=1
+
+RUN curl -O https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz && \
+    tar zxf swiftly-$(uname -m).tar.gz && \
+    ./swiftly init --platform ubi9 --quiet-shell-followup -y && \
+    . "${SWIFTLY_HOME_DIR:-$HOME/.local/share/swiftly}/env.sh" && \
+    hash -r
+
+RUN /root/files/swift/create-sdk-bundle.sh /root/Xcode.app/Contents/Developer /root/.swiftpm/swift-sdks
 
 CMD /bin/bash

--- a/Dockerfile.xcode
+++ b/Dockerfile.xcode
@@ -9,6 +9,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     clang -O3 -llzma -lxar -I /usr/local/include pbzx.c -o pbzx
 
 ENV XCODE_SDKV=
+ENV APPLE_SDKV=
 ENV OSX_SDKV=
 ENV IOS_SDKV=
 ENV TVOS_SDKV=

--- a/build.sh
+++ b/build.sh
@@ -58,14 +58,9 @@ podman_build windows
 podman_build web
 podman_build android
 
-XCODE_SDK=16.4
-OSX_SDK=15.5
-IOS_SDK=18.5
-TVOS_SDK=18.5
-VISIONOS_SDK=2.5
-if [ ! -e "${files_root}"/MacOSX${OSX_SDK}.sdk.tar.xz ] || [ ! -e "${files_root}"/iPhoneOS${IOS_SDK}.sdk.tar.xz ] || [ ! -e "${files_root}"/iPhoneSimulator${IOS_SDK}.sdk.tar.xz ] \
-|| [ ! -e "${files_root}"/AppleTVOS${TVOS_SDK}.sdk.tar.xz ] || [ ! -e "${files_root}"/AppleTVSimulator${TVOS_SDK}.sdk.tar.xz ] \
-|| [ ! -e "${files_root}"/XROS${VISIONOS_SDK}.sdk.tar.xz ] || [ ! -e "${files_root}"/XRSimulator${VISIONOS_SDK}.sdk.tar.xz ]; then
+XCODE_SDK=26.0.1
+APPLE_SDKV=26.0
+if [ ! -e "${files_root}"/MacOSX${APPLE_SDKV}.sdk.tar.xz ] || [ ! -e "${files_root}"/Xcode-Developer${XCODE_SDK}.tar.xz ]; then
   if [ ! -r "${files_root}"/Xcode_${XCODE_SDK}.xip ]; then
     echo
     echo "Error: 'files/Xcode_${XCODE_SDK}.xip' is required for Apple platforms, but was not found or couldn't be read."
@@ -78,10 +73,7 @@ if [ ! -e "${files_root}"/MacOSX${OSX_SDK}.sdk.tar.xz ] || [ ! -e "${files_root}
   "$podman" run -it --rm \
     -v "${files_root}":/root/files:z \
     -e XCODE_SDKV="${XCODE_SDK}" \
-    -e OSX_SDKV="${OSX_SDK}" \
-    -e IOS_SDKV="${IOS_SDK}" \
-    -e TVOS_SDKV="${TVOS_SDK}" \
-    -e VISIONOS_SDKV="${VISIONOS_SDK}" \
+    -e APPLE_SDKV="${APPLE_SDKV}" \
     godot-xcode:${img_version} \
     2>&1 | tee logs/xcode_packer.log
 fi

--- a/extract_xcode_sdks.sh
+++ b/extract_xcode_sdks.sh
@@ -10,10 +10,7 @@ EXTRACT_FROM_XIP="${EXTRACT_FROM_XIP:-1}"
 OUT_DIR="${OUT_DIR:-/root/files}"
 
 # SDK versions (should be set via env or Dockerfile)
-OSX_SDKV="${OSX_SDKV:-}"
-IOS_SDKV="${IOS_SDKV:-}"
-TVOS_SDKV="${TVOS_SDKV:-}"
-VISIONOS_SDKV="${VISIONOS_SDKV:-}"
+APPLE_SDKV="${APPLE_SDKV:-}"
 
 # Which SDKs to extract (set to 1 to enable)
 # Note: These defaults are overridden below based on execution context
@@ -29,21 +26,11 @@ fi
 
 if [[ "${EXTRACT_FROM_XIP:-1}" == "1" ]]; then
   EXTRACT_MACOS="${EXTRACT_MACOS:-1}"
-  EXTRACT_IOS="${EXTRACT_IOS:-1}"
-  EXTRACT_IOS_SIM="${EXTRACT_IOS_SIM:-1}"
-  EXTRACT_TVOS="${EXTRACT_TVOS:-1}"
-  EXTRACT_TVOS_SIM="${EXTRACT_TVOS_SIM:-1}"
-  EXTRACT_VISIONOS="${EXTRACT_VISIONOS:-1}"
-  EXTRACT_VISIONOS_SIM="${EXTRACT_VISIONOS_SIM:-1}"
+  EXTRACT_XCODE="${EXTRACT_XCODE:-1}"
 else
   # When called manually, require explicit SDK selection
   EXTRACT_MACOS="${EXTRACT_MACOS:-0}"
-  EXTRACT_IOS="${EXTRACT_IOS:-0}"
-  EXTRACT_IOS_SIM="${EXTRACT_IOS_SIM:-0}"
-  EXTRACT_TVOS="${EXTRACT_TVOS:-0}"
-  EXTRACT_TVOS_SIM="${EXTRACT_TVOS_SIM:-0}"
-  EXTRACT_VISIONOS="${EXTRACT_VISIONOS:-0}"
-  EXTRACT_VISIONOS_SIM="${EXTRACT_VISIONOS_SIM:-0}"
+  EXTRACT_XCODE="${EXTRACT_XCODE:-0}"
 fi
 
 extract_and_pack() {
@@ -57,7 +44,7 @@ extract_and_pack() {
     # Use tar to copy and preserve everything, then repackage
     echo "=== Copying SDK using tar to preserve special files ==="
     cd "$sdk_dir"
-    tar -cf - "$sdk_name" | (cd "/tmp" && tar -xf -)
+    tar -cf - "$sdk_name" | tar -xf - -C /tmp
 
     # Rename to versioned name
     mv "/tmp/$sdk_name" "/tmp/$versioned_name"
@@ -73,10 +60,11 @@ extract_and_pack() {
     fi
 
     # Create tar with versioned directory name
-    tar -cJf "$OUT_DIR/$tar_name" -C "/tmp" "$versioned_name"
+    tar -cJf "/tmp/$tar_name" -C "/tmp" "$versioned_name"
 
     # Clean up temporary directory
     rm -rf "/tmp/$versioned_name"
+    mv "/tmp/$tar_name" "$OUT_DIR/$tar_name"
 
     echo "✓ Packed $tar_name"
   else
@@ -85,67 +73,22 @@ extract_and_pack() {
   fi
 }
 
+# Xcode Developer
+if [[ "$EXTRACT_XCODE" == "1" ]]; then
+  extract_and_pack \
+    "$XCODE_APP_PATH/Contents" \
+    "Developer" \
+    "Xcode-Developer${XCODE_SDKV}" \
+    "Xcode-Developer${XCODE_SDKV}.tar.xz"
+fi
+
 # macOS SDK
 if [[ "$EXTRACT_MACOS" == "1" ]]; then
   extract_and_pack \
     "$XCODE_APP_PATH/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs" \
     "MacOSX.sdk" \
-    "MacOSX${OSX_SDKV}.sdk" \
-    "MacOSX${OSX_SDKV}.sdk.tar.xz"
-fi
-
-# iOS SDK
-if [[ "$EXTRACT_IOS" == "1" ]]; then
-  extract_and_pack \
-    "$XCODE_APP_PATH/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs" \
-    "iPhoneOS.sdk" \
-    "iPhoneOS${IOS_SDKV}.sdk" \
-    "iPhoneOS${IOS_SDKV}.sdk.tar.xz"
-fi
-
-# iOS Simulator SDK
-if [[ "$EXTRACT_IOS_SIM" == "1" ]]; then
-  extract_and_pack \
-    "$XCODE_APP_PATH/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs" \
-    "iPhoneSimulator.sdk" \
-    "iPhoneSimulator${IOS_SDKV}.sdk" \
-    "iPhoneSimulator${IOS_SDKV}.sdk.tar.xz"
-fi
-
-# tvOS SDK
-if [[ "$EXTRACT_TVOS" == "1" ]]; then
-  extract_and_pack \
-    "$XCODE_APP_PATH/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs" \
-    "AppleTVOS.sdk" \
-    "AppleTVOS${TVOS_SDKV}.sdk" \
-    "AppleTVOS${TVOS_SDKV}.sdk.tar.xz"
-fi
-
-# tvOS Simulator SDK
-if [[ "$EXTRACT_TVOS_SIM" == "1" ]]; then
-  extract_and_pack \
-    "$XCODE_APP_PATH/Contents/Developer/Platforms/AppleTVSimulator.platform/Developer/SDKs" \
-    "AppleTVSimulator.sdk" \
-    "AppleTVSimulator${TVOS_SDKV}.sdk" \
-    "AppleTVSimulator${TVOS_SDKV}.sdk.tar.xz"
-fi
-
-# visionOS SDK
-if [[ "$EXTRACT_VISIONOS" == "1" ]]; then
-  extract_and_pack \
-    "$XCODE_APP_PATH/Contents/Developer/Platforms/XROS.platform/Developer/SDKs" \
-    "XROS.sdk" \
-    "XROS${VISIONOS_SDKV}.sdk" \
-    "XROS${VISIONOS_SDKV}.sdk.tar.xz"
-fi
-
-# visionOS Simulator SDK
-if [[ "$EXTRACT_VISIONOS_SIM" == "1" ]]; then
-  extract_and_pack \
-    "$XCODE_APP_PATH/Contents/Developer/Platforms/XRSimulator.platform/Developer/SDKs" \
-    "XRSimulator.sdk" \
-    "XRSimulator${VISIONOS_SDKV}.sdk" \
-    "XRSimulator${VISIONOS_SDKV}.sdk.tar.xz"
+    "MacOSX${APPLE_SDKV}.sdk" \
+    "MacOSX${APPLE_SDKV}.sdk.tar.xz"
 fi
 
 echo "Done extracting selected SDKs."

--- a/files/appleembedded/check-arm.sh
+++ b/files/appleembedded/check-arm.sh
@@ -4,15 +4,14 @@ function check_toolchain
 {
     local platform=$1
     local sdk_prefix=$2
-    local sdk_version=$3
-    # if $4 is true, use the simulator SDK
-    if [ "$4" == "true" ]; then
-        SDK_DIR="/root/SDKs/${sdk_prefix}Simulator${sdk_version}.sdk"
-        TARGET_OS="${platform}${sdk_version}-simulator"
+    # if $3 is true, use the simulator SDK
+    if [ "$3" == "true" ]; then
+        SDK_DIR="/root/Xcode.app/Contents/Developer/Platforms/${sdk_prefix}Simulator.platform/Developer/SDKs/${sdk_prefix}Simulator.sdk"
+        TARGET_OS="${platform}${APPLE_SDKV}-simulator"
         NAME="${platform} (Simulator)"
     else
-        SDK_DIR="/root/SDKs/${sdk_prefix}OS${sdk_version}.sdk"
-        TARGET_OS="${platform}${sdk_version}"
+        SDK_DIR="/root/Xcode.app/Contents/Developer/Platforms/${sdk_prefix}OS.platform/Developer/SDKs/${sdk_prefix}OS.sdk"
+        TARGET_OS="${platform}${APPLE_SDKV}"
         NAME="${platform} (Device)"
     fi
 
@@ -27,11 +26,11 @@ function check_toolchain
     echo "${NAME} toolchain OK"
 }
 
-check_toolchain "ios" "iPhone" "$IOS_SDK" false
-check_toolchain "tvos" "AppleTV" "$TVOS_SDK" false
-check_toolchain "xros" "XR" "$XROS_SDK" false
+check_toolchain "ios" "iPhone" false
+check_toolchain "tvos" "AppleTV" false
+check_toolchain "xros" "XR" false
 # Check for simulator toolchains
-check_toolchain "ios" "iPhone" "$IOS_SDK" true
-check_toolchain "tvos" "AppleTV" "$TVOS_SDK" true
-check_toolchain "xros" "XR" "$XROS_SDK" true
+check_toolchain "ios" "iPhone" true
+check_toolchain "tvos" "AppleTV" true
+check_toolchain "xros" "XR" true
 

--- a/files/swift/create-sdk-bundle.sh
+++ b/files/swift/create-sdk-bundle.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+set -e
+
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <path-to-xcode-developer-dir> <output-dir>"
+    echo "Example: $0 /path/to/Xcode.app/Contents/Developer ./sdk-bundle"
+    exit 1
+fi
+
+DEV_DIR="$1"
+OUTPUT="$2/darwin.artifactbundle"
+
+echo "Creating artifact bundle at $OUTPUT"
+mkdir -p "$OUTPUT"
+
+# Find SDKs
+find_sdk() {
+    local platform=$1
+    local prefix=$2
+    local sdk_dir="$DEV_DIR/Platforms/$platform.platform/Developer/SDKs"
+    ls -1 "$sdk_dir" 2>/dev/null | grep "^$prefix[0-9]" | head -1 || echo ""
+}
+
+IOS_SDK=$(find_sdk "iPhoneOS" "iPhoneOS")
+SIM_SDK=$(find_sdk "iPhoneSimulator" "iPhoneSimulator")
+MAC_SDK=$(find_sdk "MacOSX" "MacOSX")
+TVOS_SDK=$(find_sdk "AppleTVOS" "AppleTVOS")
+TVSIM_SDK=$(find_sdk "AppleTVSimulator" "AppleTVSimulator")
+XROS_SDK=$(find_sdk "XROS" "XROS")
+XRSIM_SDK=$(find_sdk "XRSimulator" "XRSimulator")
+
+echo "Found SDKs:"
+[ -n "$IOS_SDK" ] && echo "  iOS: $IOS_SDK"
+[ -n "$SIM_SDK" ] && echo "  iOS Sim: $SIM_SDK"
+[ -n "$MAC_SDK" ] && echo "  macOS: $MAC_SDK"
+[ -n "$TVOS_SDK" ] && echo "  tvOS: $TVOS_SDK"
+[ -n "$TVSIM_SDK" ] && echo "  tvOS Sim: $TVSIM_SDK"
+[ -n "$XROS_SDK" ] && echo "  visionOS: $XROS_SDK"
+[ -n "$XRSIM_SDK" ] && echo "  visionOS Sim: $XRSIM_SDK"
+
+# Symlink Developer directory
+ln -sf "$DEV_DIR" "$OUTPUT/Developer"
+
+# Generate info.json
+cat > "$OUTPUT/info.json" <<EOF
+{
+    "schemaVersion": "1.0",
+    "artifacts": {
+        "darwin": {
+            "type": "swiftSDK",
+            "version": "0.0.1",
+            "variants": [
+                {
+                    "path": ".",
+                    "supportedTriples": ["aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu"]
+                }
+            ]
+        }
+    }
+}
+EOF
+
+# Generate toolset.json
+cat > "$OUTPUT/toolset.json" <<EOF
+{
+    "schemaVersion": "1.0",
+    "rootPath": "toolset/bin",
+    "linker": {
+        "path": "ld64.lld"
+    },
+    "swiftCompiler": {
+        "extraCLIOptions": [
+            "-Xfrontend", "-enable-cross-import-overlays",
+            "-use-ld=lld"
+        ]
+    }
+}
+EOF
+
+# Generate swift-sdk.json
+cat > "$OUTPUT/swift-sdk.json" <<EOF
+{
+    "schemaVersion": "4.0",
+    "targetTriples": {
+EOF
+
+first=true
+add_triple() {
+    local triple=$1 platform=$2 sdk=$3
+    [ -z "$sdk" ] && return
+    [ "$first" = false ] && echo "," >> "$OUTPUT/swift-sdk.json"
+    first=false
+    cat >> "$OUTPUT/swift-sdk.json" <<TRIPLE
+        "$triple": {
+            "sdkRootPath": "Developer/Platforms/$platform.platform/Developer/SDKs/$sdk",
+            "includeSearchPaths": ["Developer/Platforms/$platform.platform/Developer/usr/lib"],
+            "librarySearchPaths": ["Developer/Platforms/$platform.platform/Developer/usr/lib"],
+            "swiftResourcesPath": "Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift",
+            "swiftStaticResourcesPath": "Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift_static",
+            "toolsetPaths": ["toolset.json"]
+        }
+TRIPLE
+}
+
+add_triple "arm64-apple-ios" "iPhoneOS" "$IOS_SDK"
+add_triple "arm64-apple-ios-simulator" "iPhoneSimulator" "$SIM_SDK"
+add_triple "x86_64-apple-ios-simulator" "iPhoneSimulator" "$SIM_SDK"
+add_triple "arm64-apple-macosx" "MacOSX" "$MAC_SDK"
+add_triple "x86_64-apple-macosx" "MacOSX" "$MAC_SDK"
+add_triple "arm64-apple-tvos" "AppleTVOS" "$TVOS_SDK"
+add_triple "arm64-apple-tvos-simulator" "AppleTVSimulator" "$TVSIM_SDK"
+add_triple "x86_64-apple-tvos-simulator" "AppleTVSimulator" "$TVSIM_SDK"
+add_triple "arm64-apple-xros" "XROS" "$XROS_SDK"
+add_triple "arm64-apple-xros-simulator" "XRSimulator" "$XRSIM_SDK"
+
+cat >> "$OUTPUT/swift-sdk.json" <<EOF
+
+    }
+}
+EOF


### PR DESCRIPTION
This PR:

* Updates to the latest Xcode version
* Installs the swift 6.2 toolchain for macOS and Apple embedded containers
* Updates to llvm 21

## iOS Build Status

- ✅ iOS successfully builds with Swift source additions

## visionOS Build Status

- ❌ visionOS does not build, because of swiftlang/llvm-project/issues/10782, and is the same problem that I patched for compiling C / C++ / Objective-C / Objective-C++

When the swift compiler attempts to compile modules that have the same availability checks as is mentioned in swiftlang/llvm-project/issues/10782, it fails due to the bug in llvm

In order to resolve this, the Swift 6.2 toolchain will need to be compiled with the same patched llvm-project toolchain.