### PR TITLE
[3.x] Update to Fedora 42, Mono 6.12.0.206 w/ Android 16KB page size, Xcode 16.2

### DIFF
--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -7,15 +7,17 @@ ENV ANDROID_SDK_ROOT=/root/sdk
 ENV ANDROID_NDK_VERSION=23.2.8568313
 ENV ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk/${ANDROID_NDK_VERSION}
 
-RUN dnf -y install --setopt=install_weak_deps=False \
-      java-17-openjdk-devel ncurses-compat-libs && \
+RUN dnf -y install adoptium-temurin-java-repository && \
+    dnf config-manager setopt adoptium-temurin-java-repository.enabled=1 && \
+    dnf -y install --setopt=install_weak_deps=False \
+      temurin-17-jdk ncurses-compat-libs && \
     mkdir -p sdk && cd sdk && \
-    export CMDLINETOOLS=commandlinetools-linux-10406996_latest.zip && \
+    export CMDLINETOOLS=commandlinetools-linux-13114758_latest.zip && \
     curl -LO https://dl.google.com/android/repository/${CMDLINETOOLS} && \
     unzip ${CMDLINETOOLS} && \
     rm ${CMDLINETOOLS} && \
     yes | cmdline-tools/bin/sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" --licenses && \
-    cmdline-tools/bin/sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" "ndk;${ANDROID_NDK_VERSION}" 'cmdline-tools;latest' 'build-tools;33.0.2' 'platforms;android-33' 'cmake;3.22.1'
+    cmdline-tools/bin/sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" "ndk;${ANDROID_NDK_VERSION}" 'cmdline-tools;latest' 'build-tools;34.0.0' 'platforms;android-34' 'cmake;3.31.6'
 
 RUN cp -a /root/files/${mono_version} /root && \
     export MONO_SOURCE_ROOT=/root/${mono_version} && \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,9 +1,9 @@
-FROM fedora:39
+FROM fedora:42
 
 WORKDIR /root
 
 RUN dnf -y install --setopt=install_weak_deps=False \
-      bash bzip2 curl file findutils gettext git make nano patch pkgconfig python3-pip unzip which xz && \
-    pip install scons==4.5.2
+      bash binutils bzip2 curl file findutils gettext git make nano patch pkgconfig python3-pip unzip which xz && \
+    pip install scons==4.10.0
 
 CMD /bin/bash

--- a/Dockerfile.export
+++ b/Dockerfile.export
@@ -1,8 +1,10 @@
 ARG img_version
 FROM godot-fedora:${img_version}
 
-RUN dnf -y install --setopt=install_weak_deps=False \
+RUN dnf -y install adoptium-temurin-java-repository && \
+    dnf config-manager setopt adoptium-temurin-java-repository.enabled=1 && \
+    dnf -y install --setopt=install_weak_deps=False \
       xorg-x11-server-Xvfb libXcursor libXinerama libXrandr libXi \
-      alsa-lib pulseaudio-libs mesa-dri-drivers java-11-openjdk-devel
+      alsa-lib pulseaudio-libs mesa-dri-drivers temurin-17-jdk
 
 CMD /bin/bash

--- a/Dockerfile.ios
+++ b/Dockerfile.ios
@@ -3,15 +3,13 @@ FROM godot-osx:${img_version}
 
 ARG mono_version
 
-ENV IOS_SDK=17.0
+ENV IOS_SDK=18.2
 
 RUN dnf -y install --setopt=install_weak_deps=False \
       automake autoconf gcc gcc-c++ gcc-objc gcc-objc++ cmake libicu-devel libtool libxml2-devel openssl-devel perl python yasm && \
     git clone --progress https://github.com/tpoechtrager/cctools-port && \
     cd /root/cctools-port && \
-    git checkout 437ced391dbf14dce86f977ca050a750d5682f39 && \
-    curl -LO https://github.com/tpoechtrager/cctools-port/pull/136.patch && \
-    git apply 136.patch && \
+    git checkout 19383894833e22f5c41c82cacbcf2e9f5aac93da && \
     # arm64 device
     usage_examples/ios_toolchain/build.sh /root/files/iPhoneOS${IOS_SDK}.sdk.tar.xz arm64 && \
     mkdir -p /root/ioscross/arm64 && \
@@ -63,7 +61,7 @@ RUN cp -a /root/files/${mono_version} /root && \
 
 # Until we can build the cross-compiler, we include a pre-made build in the container.
 RUN mkdir -p /root/aot-compilers/iphone-arm64 && \
-    curl -LO https://github.com/godotengine/godot-mono-builds/releases/download/release-4912f62/ios-cross-arm64.zip && \
+    curl -LO https://github.com/godotengine/godot-mono-builds/releases/download/release-ae49eba/ios-cross-arm64.zip && \
     dnf -y install --setopt=install_weak_deps=False p7zip && \
     7za e ios-cross-arm64.zip ios-cross-arm64-release/bin/aarch64-apple-darwin-mono-sgen -o/root/aot-compilers/iphone-arm64 && \
     rm ios-cross-arm64.zip

--- a/Dockerfile.mono
+++ b/Dockerfile.mono
@@ -4,7 +4,7 @@ FROM godot-fedora:${img_version}
 ARG mono_version
 
 RUN dnf -y install --setopt=install_weak_deps=False \
-      autoconf automake cmake gcc gcc-c++ gettext libtool perl python-unversioned-command && \
+      autoconf automake cmake gawk gcc gcc-c++ gettext libtool perl python-unversioned-command && \
     cp -a /root/files/${mono_version} /root && \
     cd /root/${mono_version} && \
     NOCONFIGURE=1 ./autogen.sh && \

--- a/Dockerfile.msvc
+++ b/Dockerfile.msvc
@@ -1,5 +1,5 @@
 ARG img_version
-FROM godot-fedora:${img_version}
+FROM fedora:30
 
 ENV WINEDEBUG=-all
 

--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -3,18 +3,23 @@ FROM godot-mono:${img_version}
 
 ARG mono_version
 
+ENV OSX_SDK=15.2
+
 RUN dnf -y install --setopt=install_weak_deps=False \
       automake autoconf bzip2-devel cmake gcc gcc-c++ libdispatch libicu-devel libtool \
       libxml2-devel openssl-devel uuid-devel yasm && \
     git clone --progress https://github.com/tpoechtrager/osxcross && \
     cd /root/osxcross && \
-    git checkout 5e1b71fcceb23952f3229995edca1b6231525b5b && \
-    ln -s /root/files/MacOSX14.0.sdk.tar.xz /root/osxcross/tarballs && \
+    git checkout f873f534c6cdb0776e457af8c7513da1e02abe59 && \
+    curl -LO https://github.com/akien-mga/osxcross/commit/38c6b5f68499a3aaa7ead5e7afa04fe1ed6e1454.patch && \
+    git apply 38c6b5f68499a3aaa7ead5e7afa04fe1ed6e1454.patch && \
+    ln -s /root/files/MacOSX${OSX_SDK}.sdk.tar.xz /root/osxcross/tarballs && \
     export UNATTENDED=1 && \
+    export SDK_VERSION=${OSX_SDK} && \
     # Custom build Apple Clang to ensure compatibility.
     # Find the equivalent LLVM version for the SDK from:
     # https://en.wikipedia.org/wiki/Xcode#Toolchain_versions
-    CLANG_VERSION=16.0.0 ENABLE_CLANG_INSTALL=1 INSTALLPREFIX=/usr ./build_apple_clang.sh && \
+    CLANG_VERSION=17.0.6 ENABLE_CLANG_INSTALL=1 INSTALLPREFIX=/usr ./build_apple_clang.sh && \
     ./build.sh && \
     ./build_compiler_rt.sh && \
     rm -rf /root/osxcross/build
@@ -26,7 +31,7 @@ RUN cp -a /root/files/${mono_version} /root && \
     cd /root/${mono_version} && \
     patch -p1 < /root/files/patches/mono-btls-cmake-wrapper.patch && \
     export MONO_SOURCE_ROOT=/root/${mono_version} && \
-    export OSXCROSS_SDK=23 && \
+    export OSXCROSS_SDK=24.2 && \
     cd /root/${mono_version}/godot-mono-builds && \
     python3 osx.py configure -j --target=x86_64 --target=arm64 && \
     python3 osx.py make -j --target=x86_64 --target=arm64 && \

--- a/README.md
+++ b/README.md
@@ -70,17 +70,17 @@ you can comment out the corresponding lines from the script:
 These are the expected container image sizes, so you can plan your disk usage in advance:
 
     REPOSITORY                                       TAG                        SIZE
-    localhost/godot-fedora                           3.x-f39-mono-6.12.0.198    624 MB
-    localhost/godot-export                           3.x-f39-mono-6.12.0.198    1.14 GB
-    localhost/godot-mono                             3.x-f39-mono-6.12.0.198    1.52 GB
-    localhost/godot-mono-glue                        3.x-f39-mono-6.12.0.198    1.86 GB
-    localhost/godot-linux                            3.x-f39-mono-6.12.0.198    4.54 GB
-    localhost/godot-windows                          3.x-f39-mono-6.12.0.198    3.48 GB
-    localhost/godot-javascript                       3.x-f39-mono-6.12.0.198    3.97 GB
-    localhost/godot-android                          3.x-f39-mono-6.12.0.198    6.41 GB
-    localhost/godot-xcode                            3.x-f39-mono-6.12.0.198    1.07 GB
-    localhost/godot-osx                              3.x-f39-mono-6.12.0.198    6.05 GB
-    localhost/godot-ios                              3.x-f39-mono-6.12.0.198    7.48 GB
+    localhost/godot-fedora                           3.x-f42-mono-6.12.0.206    425 MB
+    localhost/godot-export                           3.x-f42-mono-6.12.0.206    1.02 GB
+    localhost/godot-mono                             3.x-f42-mono-6.12.0.206    1.31 GB
+    localhost/godot-mono-glue                        3.x-f42-mono-6.12.0.206    1.61 GB
+    localhost/godot-linux                            3.x-f42-mono-6.12.0.206    4.33 GB
+    localhost/godot-windows                          3.x-f42-mono-6.12.0.206    3.44 GB
+    localhost/godot-javascript                       3.x-f42-mono-6.12.0.206    3.76 GB
+    localhost/godot-android                          3.x-f42-mono-6.12.0.206    6.27 GB
+    localhost/godot-xcode                            3.x-f42-mono-6.12.0.206    924 MB
+    localhost/godot-osx                              3.x-f42-mono-6.12.0.206    6.13 GB
+    localhost/godot-ios                              3.x-f42-mono-6.12.0.206    7.56 GB
 
 In addition to this, generating containers will also require some host disk space
 (up to 30 GB) for the downloaded Mono sources and dependencies (Xcode, MSVC).
@@ -90,14 +90,14 @@ In addition to this, generating containers will also require some host disk spac
 
 These are the toolchains currently in use for Godot 3.6 and later:
 
-- Base image: Fedora 39
-- Mono version: 6.12.0.198
-- SCons: 4.5.2
+- Base image: Fedora 42
+- Mono version: 6.12.0.206
+- SCons: 4.10.0
 - Linux: GCC 13.2.0 built against glibc 2.28, binutils 2.40, from our own [Linux SDK](https://github.com/godotengine/buildroot)
-- Windows: MinGW 11.0.0, GCC 13.2.1, binutils 2.40
+- Windows: MinGW 12.0.0, GCC 14.2.1, binutils 2.43.1
 - HTML5: Emscripten 3.1.39 (standard builds), Emscripten 1.39.9 (Mono builds)
-- Android: Android NDK 23.2.8568313, build-tools 33.0.2, platform android-33, CMake 3.22.1, JDK 11
-- macOS: Xcode 15.0 with Apple Clang (LLVM 16.0.0), MacOSX SDK 14.0
-- iOS: Xcode 15.0 with Apple Clang (LLVM 16.0.0), iPhoneOS SDK 17.0
+- Android: Android NDK 23.2.8568313, build-tools 34.0.0, platform android-34, CMake 3.31.6, JDK 17
+- macOS: Xcode 16.2 with Apple Clang (LLVM 17.0.6), MacOSX SDK 15.2
+- iOS: Xcode 16.2 with Apple Clang (LLVM 17.0.6), iPhoneOS SDK 18.2
 - UWP: Visual Studio 2017, current configuration sadly not easily reproducible
   (`Dockerfile.msvc` image is not compiled by default as it doesn't work)

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ source $basedir/setup.sh
 if [ -z "$1" -o -z "$2" -o -z "$3" ]; then
   echo "Usage: $0 <godot branch> <base distro> <mono version>"
   echo
-  echo "Example: $0 3.x f39 mono-6.12.0.198"
+  echo "Example: $0 3.x f42 mono-6.12.0.206"
   echo
   echo "godot branch:"
   echo "        Informational, tracks the Godot branch these containers are intended for."
@@ -58,7 +58,7 @@ if [ ! -e ${mono_root} ]; then
   # Set up godot-mono-builds in tree
   git clone --progress https://github.com/godotengine/godot-mono-builds
   pushd godot-mono-builds
-  git checkout 4912f62a8f263e5673012de6ed489402af2d63bb
+  git checkout 3504af335ee10792cfaaa86f8483dd7127da405b
   export MONO_SOURCE_ROOT=${mono_root}
   python3 patch_mono.py
   popd
@@ -90,9 +90,9 @@ podman_build windows
 podman_build javascript
 podman_build android
 
-XCODE_SDK=15
-OSX_SDK=14.0
-IOS_SDK=17.0
+XCODE_SDK=16.2
+OSX_SDK=15.2
+IOS_SDK=18.2
 if [ ! -e "${files_root}"/MacOSX${OSX_SDK}.sdk.tar.xz ] || [ ! -e "${files_root}"/iPhoneOS${IOS_SDK}.sdk.tar.xz ] || [ ! -e "${files_root}"/iPhoneSimulator${IOS_SDK}.sdk.tar.xz ]; then
   if [ ! -e "${files_root}"/Xcode_${XCODE_SDK}.xip ]; then
     echo ""${files_root}"/Xcode_${XCODE_SDK}.xip is required. It can be downloaded from https://developer.apple.com/download/more/ with a valid apple ID."


### PR DESCRIPTION
Newer versions of Xcode / Clang seem to have build errors for Mono.