### PR TITLE
[3.x] Update to Fedora 43 for MinGW-GCC 15.2.1

### DIFF
--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -4,7 +4,7 @@ FROM godot-mono:${img_version}
 ARG mono_version
 
 ENV ANDROID_SDK_ROOT=/root/sdk
-ENV ANDROID_NDK_VERSION=23.2.8568313
+ENV ANDROID_NDK_VERSION=28.1.13356709
 ENV ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk/${ANDROID_NDK_VERSION}
 
 RUN dnf -y install adoptium-temurin-java-repository && \
@@ -17,7 +17,7 @@ RUN dnf -y install adoptium-temurin-java-repository && \
     unzip ${CMDLINETOOLS} && \
     rm ${CMDLINETOOLS} && \
     yes | cmdline-tools/bin/sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" --licenses && \
-    cmdline-tools/bin/sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" "ndk;${ANDROID_NDK_VERSION}" 'cmdline-tools;latest' 'build-tools;34.0.0' 'platforms;android-34' 'cmake;3.31.6'
+    cmdline-tools/bin/sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" "ndk;${ANDROID_NDK_VERSION}" 'cmdline-tools;latest' 'build-tools;35.0.0' 'platforms;android-35' 'cmake;3.31.6'
 
 RUN cp -a /root/files/${mono_version} /root && \
     export MONO_SOURCE_ROOT=/root/${mono_version} && \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM fedora:42
+FROM fedora:43
 
 WORKDIR /root
 

--- a/Dockerfile.ios
+++ b/Dockerfile.ios
@@ -42,13 +42,13 @@ RUN cp -a /root/files/${mono_version} /root && \
     cd /root/${mono_version} && \
     cd godot-mono-builds && \
     export MONO_SOURCE_ROOT=/root/${mono_version} && \
-    python3 ios.py configure -j --target=arm64 --ios-version-min 10.0 --osx-toolchain ${OSXCROSS_ROOT} \
+    python3 ios.py configure -j --target=arm64 --ios-version-min 12.0 --osx-toolchain ${OSXCROSS_ROOT} \
       --ios-toolchain ${IOSCROSS_ROOT}/arm64 --ios-sdk ${IOSCROSS_ROOT}/arm64/SDK/iPhoneOS${IOS_SDK}.sdk && \
     python3 ios.py make -j --target=arm64 && \
-    python3 ios.py configure -j --target=arm64-sim --ios-version-min 10.0 --osx-toolchain ${OSXCROSS_ROOT} \
+    python3 ios.py configure -j --target=arm64-sim --ios-version-min 12.0 --osx-toolchain ${OSXCROSS_ROOT} \
       --ios-toolchain ${IOSCROSS_ROOT}/arm64_sim --ios-sdk ${IOSCROSS_ROOT}/arm64_sim/SDK/iPhoneSimulator${IOS_SDK}.sdk && \
     python3 ios.py make -j --target=arm64-sim && \
-    python3 ios.py configure -j --target=x86_64 --ios-version-min 10.0 --osx-toolchain ${OSXCROSS_ROOT} \
+    python3 ios.py configure -j --target=x86_64 --ios-version-min 12.0 --osx-toolchain ${OSXCROSS_ROOT} \
       --ios-toolchain ${IOSCROSS_ROOT}/x86_64_sim --ios-sdk ${IOSCROSS_ROOT}/x86_64_sim/SDK/iPhoneSimulator${IOS_SDK}.sdk && \
     python3 ios.py make -j --target=x86_64 && \
     python3 bcl.py make -j --product=ios && \

--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -10,9 +10,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
       libxml2-devel openssl-devel uuid-devel yasm && \
     git clone --progress https://github.com/tpoechtrager/osxcross && \
     cd /root/osxcross && \
-    git checkout f873f534c6cdb0776e457af8c7513da1e02abe59 && \
-    curl -LO https://github.com/akien-mga/osxcross/commit/38c6b5f68499a3aaa7ead5e7afa04fe1ed6e1454.patch && \
-    git apply 38c6b5f68499a3aaa7ead5e7afa04fe1ed6e1454.patch && \
+    git checkout 3b544be4cc879afaee041207af99c7a380634a44 && \
     ln -s /root/files/MacOSX${OSX_SDK}.sdk.tar.xz /root/osxcross/tarballs && \
     export UNATTENDED=1 && \
     export SDK_VERSION=${OSX_SDK} && \

--- a/README.md
+++ b/README.md
@@ -37,16 +37,16 @@ The `build.sh` script included is used to build the containers themselves.
 
 The first two arguments can take any value and are meant to convey what Godot branch
 you are building for (e.g. `3.x`) and what Linux distribution the `Dockerfile.base`
-is based on (e.g. `f36` for Fedora 36).
+is based on (e.g. `f43` for Fedora 43).
 
 The third argument is important and should be the name of a tagged Mono release from
 the upstream `2020-02` branch (e.g. `mono-6.12.0.182`).
 
 Run the command using:
 
-    ./build.sh 3.x f39 mono-6.12.0.198
+    ./build.sh 3.x f43 mono-6.12.0.206
 
-The above will generate images using the tag '3.x-f39-mono-6.12.0.198'.
+The above will generate images using the tag '3.x-f43-mono-6.12.0.206'.
 You can then specify it in the `build.sh` of
 [godot-build-scripts](https://github.com/godotengine/godot-build-scripts).
 
@@ -70,17 +70,17 @@ you can comment out the corresponding lines from the script:
 These are the expected container image sizes, so you can plan your disk usage in advance:
 
     REPOSITORY                                       TAG                        SIZE
-    localhost/godot-fedora                           3.x-f42-mono-6.12.0.206    425 MB
-    localhost/godot-export                           3.x-f42-mono-6.12.0.206    1.02 GB
-    localhost/godot-mono                             3.x-f42-mono-6.12.0.206    1.31 GB
-    localhost/godot-mono-glue                        3.x-f42-mono-6.12.0.206    1.61 GB
-    localhost/godot-linux                            3.x-f42-mono-6.12.0.206    4.33 GB
-    localhost/godot-windows                          3.x-f42-mono-6.12.0.206    3.44 GB
-    localhost/godot-javascript                       3.x-f42-mono-6.12.0.206    3.76 GB
-    localhost/godot-android                          3.x-f42-mono-6.12.0.206    6.27 GB
-    localhost/godot-xcode                            3.x-f42-mono-6.12.0.206    924 MB
-    localhost/godot-osx                              3.x-f42-mono-6.12.0.206    6.13 GB
-    localhost/godot-ios                              3.x-f42-mono-6.12.0.206    7.56 GB
+    localhost/godot-fedora                           3.x-f43-mono-6.12.0.206    434 MB
+    localhost/godot-export                           3.x-f43-mono-6.12.0.206    1.03 GB
+    localhost/godot-mono                             3.x-f43-mono-6.12.0.206    1.32 GB
+    localhost/godot-mono-glue                        3.x-f43-mono-6.12.0.206    1.61 GB
+    localhost/godot-linux                            3.x-f43-mono-6.12.0.206    4.34 GB
+    localhost/godot-windows                          3.x-f43-mono-6.12.0.206    3.54 GB
+    localhost/godot-javascript                       3.x-f43-mono-6.12.0.206    3.77 GB
+    localhost/godot-android                          3.x-f43-mono-6.12.0.206    8.57 GB
+    localhost/godot-xcode                            3.x-f43-mono-6.12.0.206    1.01 GB
+    localhost/godot-osx                              3.x-f43-mono-6.12.0.206    6.13 GB
+    localhost/godot-ios                              3.x-f43-mono-6.12.0.206    7.56 GB
 
 In addition to this, generating containers will also require some host disk space
 (up to 30 GB) for the downloaded Mono sources and dependencies (Xcode, MSVC).
@@ -90,13 +90,13 @@ In addition to this, generating containers will also require some host disk spac
 
 These are the toolchains currently in use for Godot 3.6 and later:
 
-- Base image: Fedora 42
+- Base image: Fedora 43
 - Mono version: 6.12.0.206
 - SCons: 4.10.0
 - Linux: GCC 13.2.0 built against glibc 2.28, binutils 2.40, from our own [Linux SDK](https://github.com/godotengine/buildroot)
-- Windows: MinGW 12.0.0, GCC 14.2.1, binutils 2.43.1
+- Windows: MinGW 13.0.0, GCC 15.2.1, binutils 2.45
 - HTML5: Emscripten 3.1.39 (standard builds), Emscripten 1.39.9 (Mono builds)
-- Android: Android NDK 23.2.8568313, build-tools 34.0.0, platform android-34, CMake 3.31.6, JDK 17
+- Android: Android NDK 28.1.13356709, build-tools 35.0.0, platform android-35, CMake 3.31.6, JDK 17
 - macOS: Xcode 16.2 with Apple Clang (LLVM 17.0.6), MacOSX SDK 15.2
 - iOS: Xcode 16.2 with Apple Clang (LLVM 17.0.6), iPhoneOS SDK 18.2
 - UWP: Visual Studio 2017, current configuration sadly not easily reproducible

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ source $basedir/setup.sh
 if [ -z "$1" -o -z "$2" -o -z "$3" ]; then
   echo "Usage: $0 <godot branch> <base distro> <mono version>"
   echo
-  echo "Example: $0 3.x f42 mono-6.12.0.206"
+  echo "Example: $0 3.x f43 mono-6.12.0.206"
   echo
   echo "godot branch:"
   echo "        Informational, tracks the Godot branch these containers are intended for."


### PR DESCRIPTION
Fixes #157, seems like the MinGW stack in F42 was broken.

Still needs testing to validate the changes.