### PR TITLE
[Linux] Fix separate debug symbols for arm

### DIFF
--- a/Dockerfile.linux
+++ b/Dockerfile.linux
@@ -13,23 +13,31 @@ RUN dnf install -y wayland-devel && \
     rm -f x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     cd x86_64-godot-linux-gnu_sdk-buildroot && \
     ./relocate-sdk.sh && \
+    ln -s x86_64-godot-linux-gnu-objcopy bin/objcopy && \
+    ln -s x86_64-godot-linux-gnu-strip bin/strip && \
     cd /root && \
     curl -LO https://github.com/godotengine/buildroot/releases/download/godot-2023.08.x-4/i686-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     tar xf i686-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     rm -f i686-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     cd i686-godot-linux-gnu_sdk-buildroot && \
     ./relocate-sdk.sh && \
+    ln -s i686-godot-linux-gnu-objcopy bin/objcopy && \
+    ln -s i686-godot-linux-gnu-strip bin/strip && \
     cd /root && \
     curl -LO https://github.com/godotengine/buildroot/releases/download/godot-2023.08.x-4/aarch64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     tar xf aarch64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     rm -f aarch64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     cd aarch64-godot-linux-gnu_sdk-buildroot && \
     ./relocate-sdk.sh && \
+    ln -s aarch64-godot-linux-gnu-objcopy bin/objcopy && \
+    ln -s aarch64-godot-linux-gnu-strip bin/strip && \
     cd /root && \
     curl -LO https://github.com/godotengine/buildroot/releases/download/godot-2023.08.x-4/arm-godot-linux-gnueabihf_sdk-buildroot.tar.bz2 && \
     tar xf arm-godot-linux-gnueabihf_sdk-buildroot.tar.bz2 && \
     rm -f arm-godot-linux-gnueabihf_sdk-buildroot.tar.bz2 && \
     cd arm-godot-linux-gnueabihf_sdk-buildroot && \
-    ./relocate-sdk.sh
+    ./relocate-sdk.sh && \
+    ln -s arm-godot-linux-gnueabihf-objcopy bin/objcopy && \
+    ln -s arm-godot-linux-gnueabihf-strip bin/strip
 
 CMD /bin/bash


### PR DESCRIPTION
Buildroot is missing aliases for `objcopy` and `strip` meaning that it will fall back to using the default, which doesn't have support for arm binaries.

This creates these aliases for the respective platforms (including x86_64 and 32 even though they do work with the default objcopy/strip, have not compared the results between the two but as we create aliases for other build tools I think it's best to do so here too to ensure we use buildroot consistently)

Will make an issue to track improving this as part of buildroot as well