### PR TITLE
Update various toolchains for 4.8

### DIFF
--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -1,18 +1,23 @@
 ARG img_version
 FROM godot-fedora:${img_version}
 
+# Keep NDK, JDK, build-tools and platforms in sync with Godot's
+# `platform/android/java/app/config.gradle`.
+
 ENV ANDROID_SDK_ROOT=/root/sdk
-ENV ANDROID_NDK_VERSION=28.1.13356709
+ENV ANDROID_NDK_VERSION=29.0.14206865
 ENV ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk/${ANDROID_NDK_VERSION}
 
 RUN dnf -y install --setopt=install_weak_deps=False \
-      java-21-openjdk-devel ncurses-compat-libs && \
+      adoptium-temurin-java-repository ncurses-compat-libs && \
+    dnf -y install --setopt=install_weak_deps=False \
+      --enablerepo=adoptium-temurin-java-repository temurin-17-jdk && \
     mkdir -p sdk && cd sdk && \
-    export CMDLINETOOLS=commandlinetools-linux-13114758_latest.zip && \
+    export CMDLINETOOLS=commandlinetools-linux-14742923_latest.zip && \
     curl -LO https://dl.google.com/android/repository/${CMDLINETOOLS} && \
     unzip ${CMDLINETOOLS} && \
     rm ${CMDLINETOOLS} && \
     yes | cmdline-tools/bin/sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" --licenses && \
-    cmdline-tools/bin/sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" "ndk;${ANDROID_NDK_VERSION}" 'cmdline-tools;latest' 'build-tools;35.0.1' 'platforms;android-35' 'cmake;3.31.6'
+    cmdline-tools/bin/sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" "ndk;${ANDROID_NDK_VERSION}" 'cmdline-tools;latest' 'build-tools;36.1.0' 'platforms;android-36' 'cmake;3.31.6'
 
 CMD /bin/bash

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM fedora:43
+FROM fedora:44
 
 WORKDIR /root
 
@@ -7,7 +7,7 @@ ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 
 RUN dnf -y install --setopt=install_weak_deps=False \
       bash binutils bzip2 curl file findutils gettext git make nano patch pkgconfig python3-pip unzip which xz \
-      dotnet-sdk-8.0 && \
+      dotnet-sdk-10.0 && \
     pip install scons==4.10.1
 
 CMD /bin/bash

--- a/Dockerfile.linux
+++ b/Dockerfile.linux
@@ -1,6 +1,7 @@
 ARG img_version
 FROM godot-fedora:${img_version}
 
+ENV GODOT_SDK_VERSION=godot-2026.05.x-1
 ENV GODOT_SDK_LINUX_X86_64=/root/x86_64-godot-linux-gnu_sdk-buildroot
 ENV GODOT_SDK_LINUX_X86_32=/root/i686-godot-linux-gnu_sdk-buildroot
 ENV GODOT_SDK_LINUX_ARM64=/root/aarch64-godot-linux-gnu_sdk-buildroot
@@ -8,36 +9,28 @@ ENV GODOT_SDK_LINUX_ARM32=/root/arm-godot-linux-gnueabihf_sdk-buildroot
 ENV BASE_PATH=${PATH}
 
 RUN dnf install -y wayland-devel && \
-    curl -LO https://github.com/godotengine/buildroot/releases/download/godot-2023.08.x-4/x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
+    curl -LO https://github.com/godotengine/buildroot/releases/download/${GODOT_SDK_VERSION}/x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     tar xf x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     rm -f x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     cd x86_64-godot-linux-gnu_sdk-buildroot && \
     ./relocate-sdk.sh && \
-    ln -s x86_64-godot-linux-gnu-objcopy bin/objcopy && \
-    ln -s x86_64-godot-linux-gnu-strip bin/strip && \
     cd /root && \
-    curl -LO https://github.com/godotengine/buildroot/releases/download/godot-2023.08.x-4/i686-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
+    curl -LO https://github.com/godotengine/buildroot/releases/download/${GODOT_SDK_VERSION}/i686-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     tar xf i686-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     rm -f i686-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     cd i686-godot-linux-gnu_sdk-buildroot && \
     ./relocate-sdk.sh && \
-    ln -s i686-godot-linux-gnu-objcopy bin/objcopy && \
-    ln -s i686-godot-linux-gnu-strip bin/strip && \
     cd /root && \
-    curl -LO https://github.com/godotengine/buildroot/releases/download/godot-2023.08.x-4/aarch64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
+    curl -LO https://github.com/godotengine/buildroot/releases/download/${GODOT_SDK_VERSION}/aarch64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     tar xf aarch64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     rm -f aarch64-godot-linux-gnu_sdk-buildroot.tar.bz2 && \
     cd aarch64-godot-linux-gnu_sdk-buildroot && \
     ./relocate-sdk.sh && \
-    ln -s aarch64-godot-linux-gnu-objcopy bin/objcopy && \
-    ln -s aarch64-godot-linux-gnu-strip bin/strip && \
     cd /root && \
-    curl -LO https://github.com/godotengine/buildroot/releases/download/godot-2023.08.x-4/arm-godot-linux-gnueabihf_sdk-buildroot.tar.bz2 && \
+    curl -LO https://github.com/godotengine/buildroot/releases/download/${GODOT_SDK_VERSION}/arm-godot-linux-gnueabihf_sdk-buildroot.tar.bz2 && \
     tar xf arm-godot-linux-gnueabihf_sdk-buildroot.tar.bz2 && \
     rm -f arm-godot-linux-gnueabihf_sdk-buildroot.tar.bz2 && \
     cd arm-godot-linux-gnueabihf_sdk-buildroot && \
-    ./relocate-sdk.sh && \
-    ln -s arm-godot-linux-gnueabihf-objcopy bin/objcopy && \
-    ln -s arm-godot-linux-gnueabihf-strip bin/strip
+    ./relocate-sdk.sh
 
 CMD /bin/bash

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,9 +1,10 @@
 ARG img_version
 FROM godot-fedora:${img_version}
 
+ENV LLVM_MINGW_VERSION=20260616
+
 RUN dnf -y install --setopt=install_weak_deps=False \
       mingw32-gcc mingw32-gcc-c++ mingw32-winpthreads-static mingw64-gcc mingw64-gcc-c++ mingw64-winpthreads-static && \
-    export LLVM_MINGW_VERSION=20251118 && \
     export LLVM_MINGW_NAME=llvm-mingw-${LLVM_MINGW_VERSION}-ucrt-ubuntu-22.04-x86_64 && \
     curl -LO https://github.com/mstorsjo/llvm-mingw/releases/download/${LLVM_MINGW_VERSION}/${LLVM_MINGW_NAME}.tar.xz && \
     tar xf ${LLVM_MINGW_NAME}.tar.xz && \

--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ be welcome (but back when we tried we ran into performance issues).
 The `build.sh` script included is used to build the containers themselves.
 
 The two arguments can take any value and are meant to convey what Godot branch
-you are building for (e.g. `4.6`) and what Linux distribution the `Dockerfile.base`
-is based on (e.g. `f43` for Fedora 43).
+you are building for (e.g. `4.8`) and what Linux distribution the `Dockerfile.base`
+is based on (e.g. `f44` for Fedora 44).
 
 Run the command using:
 
-    ./build.sh 4.6 f43
+    ./build.sh 4.8 f44
 
-The above will generate images using the tag '4.6-f43'.
+The above will generate images using the tag '4.8-f44'.
 You can then specify it in the `build.sh` of
 [godot-build-scripts](https://github.com/godotengine/godot-build-scripts).
 
@@ -59,7 +59,7 @@ you can comment out the corresponding lines from the script:
     podman_build windows
     podman_build web
     podman_build android
-    ...
+    podman_build apple
 
 
 ## Image sizes
@@ -67,30 +67,29 @@ you can comment out the corresponding lines from the script:
 These are the expected container image sizes, so you can plan your disk usage in advance:
 
     REPOSITORY                         TAG                SIZE
-    localhost/godot-fedora             4.6-f43            978 MB
-    localhost/godot-linux              4.6-f43            2.77 GB
-    localhost/godot-windows            4.6-f43            2.65 GB
-    localhost/godot-web                4.6-f43            2.74 GB
-    localhost/godot-android            4.6-f43            4.22 GB
-    localhost/godot-xcode              4.6-f43            1.56 GB
-    localhost/godot-osx                4.6-f43            14.6 GB
-    localhost/godot-appleembedded      4.6-f43            16.0 GB
+    localhost/godot-fedora             4.8-f44            972 MB
+    localhost/godot-linux              4.8-f44            2.98 GB
+    localhost/godot-windows            4.8-f44            2.76 GB
+    localhost/godot-web                4.8-f44            2.74 GB
+    localhost/godot-android            4.8-f44            4.55 GB
+    localhost/godot-apple              4.8-f44            11.5 GB
+    localhost/godot-xcode              4.8-f44            1.56 GB
 
 In addition to this, generating containers will also require some host disk space
-(up to 10 GB) for the dependencies (Xcode).
+(up to 5 GB) for the dependencies (Xcode).
 
 
 ## Toolchains
 
 These are the toolchains currently in use for Godot 4.3 and later:
 
-- Base image: Fedora 43
+- Base image: Fedora 44
 - SCons: 4.10.1
-- Linux: GCC 13.2.0 built against glibc 2.28, binutils 2.40, from our own [Linux SDK](https://github.com/godotengine/buildroot)
+- Linux: GCC 15.2.0 built against glibc 2.34, binutils 2.46.0, from our own [Linux SDK](https://github.com/godotengine/buildroot)
 - Windows:
-  * x86_64/x86_32: MinGW 13.0.0, GCC 15.2.1, binutils 2.45
-  * arm64: llvm-mingw 20251118, LLVM 21.1.6
+  * x86_64/x86_32: MinGW 13.0.0, GCC 16.1.1, binutils 2.46.0
+  * arm64: llvm-mingw 20260616, LLVM 22.1.8
 - Web: Emscripten 4.0.20
-- Android: Android NDK 28.1.13356709, build-tools 35.0.1, platform android-35, CMake 3.31.6, JDK 21
-- Apple: Xcode 26.1.1 with Apple Clang (LLVM 19.1.5), cctools 1030.6.3, ld64 956.6
+- Android: Android NDK 29.0.14206865, build-tools 36.1.0, platform android-36, CMake 3.31.6, JDK 21
+- Apple: Xcode 26.6 with LLVM 21.1.6, Swift 6.3.2, Swiftly 1.1.2
   * SDKs: MacOSX, iPhoneOS, iPhoneSimulator, AppleTVOS, AppleTVSimulator, XROS, XRSimulator


### PR DESCRIPTION
- Fedora 44
- .NET SDK 10.0
- Linux: SDKs godot-2026.05.x-1 with GCC 15.2.0, glibc 2.34, binutils 2.46.0
- Windows: MinGW 13.0.0 (unchanged) with GCC 16.1.1, binutils 2.46.0
- Android: NDK r29, platform 36
- Apple: Xcode 26.6 with Swift 6.3.3
- Web: Unchanged, Emscripten 4.0.20 pinned